### PR TITLE
add ProtocolTriggers extension to BaseTriggers

### DIFF
--- a/src/Context.sol
+++ b/src/Context.sol
@@ -8,31 +8,31 @@ enum ContractVerificationSource {
 }
 
 enum CallType {
-  CALL,
-  CALLCODE,
-  STATICCALL,
-  DELEGATECALL,
-  CREATE,
-  CREATE2,
-  DEPLOYMENT,
-  UNKNOWN
+    CALL,
+    CALLCODE,
+    STATICCALL,
+    DELEGATECALL,
+    CREATE,
+    CREATE2,
+    DEPLOYMENT,
+    UNKNOWN
 }
 
 struct CallFrame {
-     // Address of the currently executing contract 
-    function () external returns (address) callee;    
-     // Address of the EOA / contract that invoked the current one
-    function () external returns (address) caller;      
+    // Address of the currently executing contract
+    function () external returns (address) callee;
+    // Address of the EOA / contract that invoked the current one
+    function () external returns (address) caller;
     // Address of the EOA / contract that delegated the current call (proxy)
     function () external returns (address) delegator;
     // Address of the contract that was delegated to (implementation)
     function () external returns (address) delegatee;
     // The calldata of the current call
-    function () external returns (bytes memory)  callData;
+    function () external returns (bytes memory) callData;
     // The depth of the current call
-    function () external returns (uint256)  callDepth;
+    function () external returns (uint256) callDepth;
     // Value transferred (in wei)
-    function () external returns (uint256)  value;
+    function () external returns (uint256) value;
     // The type of call
     function () external returns (CallType) callType;
     // The verification source of the current contract
@@ -41,17 +41,17 @@ struct CallFrame {
 
 struct TransactionContext {
     // The execution context of the current call
-    CallFrame  call;
+    CallFrame call;
     // Whether the external transaction is successful or reverted
     function () external returns (bool) isSuccessful;
     // Top level transaction hash
     function () external returns (bytes32) hash;
     // Network chain identifier
-    uint256 chainId; 
+    uint256 chainId;
 }
 
 struct FunctionContext {
-  TransactionContext txn;
+    TransactionContext txn;
 }
 
 struct EventContext {
@@ -59,7 +59,7 @@ struct EventContext {
 }
 
 struct PreFunctionContext {
-  TransactionContext txn;
+    TransactionContext txn;
 }
 
 struct RawCallContext {
@@ -82,5 +82,5 @@ struct RawLogContext {
 }
 
 struct RawBlockContext {
-  uint256 blockNumber;
+    uint256 blockNumber;
 }

--- a/src/ProtocolTriggers.sol
+++ b/src/ProtocolTriggers.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./Triggers.sol";
+import {ChainsEnumerableMapLib} from "./utils/ChainsEnumerableMapLib.sol";
+
+struct ProtocolConfigAddress {
+    Trigger[] triggers;
+    ChainsEnumerableMapLib.ChainsToChainIdContractMap chainIdToAddressEnumerable;
+}
+
+struct ProtocolConfigAbi {
+    Trigger[] triggers;
+    ChainsEnumerableMapLib.ChainsToChainIdAbiMap chainIdToAbiEnumerable;
+}
+
+abstract contract ProtocolTriggers is BaseTriggers {
+    using ChainsEnumerableMapLib for ChainsEnumerableMapLib.ChainsToChainIdContractMap;
+    using ChainsEnumerableMapLib for ChainsEnumerableMapLib.ChainsToChainIdAbiMap;
+
+    function addTriggerForProtocol(ProtocolConfigAbi storage config) internal {
+        for (uint256 i = 0; i < config.chainIdToAbiEnumerable.length(); i++) {
+            (, ChainIdAbi memory _abi) = config.chainIdToAbiEnumerable.getAtIndex(i);
+            addTriggers(_abi, config.triggers);
+        }
+    }
+
+    function addTriggerForProtocol(ProtocolConfigAddress storage config) internal {
+        for (uint256 i = 0; i < config.chainIdToAddressEnumerable.length(); i++) {
+            (, ChainIdContract memory _contract) = config.chainIdToAddressEnumerable.getAtIndex(i);
+            addTriggers(_contract, config.triggers);
+        }
+    }
+}

--- a/src/RawTriggers.sol
+++ b/src/RawTriggers.sol
@@ -5,7 +5,7 @@ import {RawTriggerType, RawTrigger} from "./Triggers.sol";
 import {RawCallContext, RawPreCallContext, RawBlockContext, RawLogContext} from "./Context.sol";
 
 abstract contract Raw$OnCall {
-    function onCall(RawCallContext memory ctx) virtual external;
+    function onCall(RawCallContext memory ctx) external virtual;
 
     function triggerOnCall() external view returns (RawTrigger memory) {
         return RawTrigger({
@@ -17,7 +17,7 @@ abstract contract Raw$OnCall {
 }
 
 abstract contract Raw$OnPreCall {
-    function onPreCall(RawPreCallContext memory ctx) virtual external;
+    function onPreCall(RawPreCallContext memory ctx) external virtual;
 
     function triggerOnPreCall() external view returns (RawTrigger memory) {
         return RawTrigger({

--- a/src/Simidx.sol
+++ b/src/Simidx.sol
@@ -4,3 +4,4 @@ pragma solidity ^0.8.13;
 import "./Context.sol";
 import "./RawTriggers.sol";
 import "./Triggers.sol";
+import "./ProtocolTriggers.sol";

--- a/src/Triggers.sol
+++ b/src/Triggers.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.13;
 
 enum BlockRangeKind {
-    RangeInclusive,    // Blocks from inclusive start to inclusive end   
-    RangeFrom,         // Blocks from inclusive start to unbounded end         
-    RangeFull          // All blocks from earliest available to unbounded end                
+    RangeInclusive, // Blocks from inclusive start to inclusive end
+    RangeFrom, // Blocks from inclusive start to unbounded end
+    RangeFull // All blocks from earliest available to unbounded end
+
 }
 
 struct BlockRange {
@@ -15,10 +16,15 @@ struct BlockRange {
 
 library BlockRangeLib {
     function withStartBlock(uint64 startBlockInclusive) internal pure returns (BlockRange memory) {
-        return BlockRange({kind: BlockRangeKind.RangeFrom, startBlockInclusive: startBlockInclusive, endBlockInclusive: 0});
+        return
+            BlockRange({kind: BlockRangeKind.RangeFrom, startBlockInclusive: startBlockInclusive, endBlockInclusive: 0});
     }
 
-    function withEndBlock(BlockRange memory range, uint64 endBlockInclusive) internal pure returns (BlockRange memory) {
+    function withEndBlock(BlockRange memory range, uint64 endBlockInclusive)
+        internal
+        pure
+        returns (BlockRange memory)
+    {
         range.endBlockInclusive = endBlockInclusive;
         range.kind = BlockRangeKind.RangeInclusive;
         return range;
@@ -85,22 +91,22 @@ library ChainsLib {
         });
     }
 
-    function withEndBlock(ChainWithRange memory chain, uint64 endBlockInclusive) internal pure returns (ChainWithRange memory) {
+    function withEndBlock(ChainWithRange memory chain, uint64 endBlockInclusive)
+        internal
+        pure
+        returns (ChainWithRange memory)
+    {
         chain.blockRange = BlockRangeLib.withEndBlock(chain.blockRange, endBlockInclusive);
         return chain;
     }
 
     function withBlockRange(Chains chain, BlockRange memory range) internal pure returns (ChainWithRange memory) {
-        return ChainWithRange({
-            chainId: chainToChainId(chain),
-            blockRange: range
-        });
+        return ChainWithRange({chainId: chainToChainId(chain), blockRange: range});
     }
 }
 
 using ChainsLib for Chains global;
 using ChainsLib for ChainWithRange global;
-
 
 enum TriggerType {
     FUNCTION,
@@ -157,7 +163,11 @@ library ChainContractLibrary {
 using ChainContractLibrary for ChainIdContract global;
 
 function chainContract(Chains chain, address contractAddress) pure returns (ChainIdContract memory) {
-    return ChainIdContract({chainId: chainToChainId(chain), contractAddress: contractAddress, blockRange: blockRangeFull()});
+    return ChainIdContract({
+        chainId: chainToChainId(chain),
+        contractAddress: contractAddress,
+        blockRange: blockRangeFull()
+    });
 }
 
 function chainContract(ChainWithRange memory chain, address contractAddress) pure returns (ChainIdContract memory) {

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import {FunctionContext, EventContext, CallFrame, TransactionContext, ContractVerificationSource, CallType} from "../Context.sol";
+import {
+    FunctionContext,
+    EventContext,
+    CallFrame,
+    TransactionContext,
+    ContractVerificationSource,
+    CallType
+} from "../Context.sol";
 
 contract MockContexts {
     address public caller;
@@ -17,15 +24,11 @@ contract MockContexts {
     bool public isSuccessful;
 
     function mockFunctionContext() external view returns (FunctionContext memory) {
-        return FunctionContext({
-            txn: this.mockBaseContext()
-        });
+        return FunctionContext({txn: this.mockBaseContext()});
     }
 
     function mockEventContext() external view returns (EventContext memory) {
-        return EventContext({
-            txn: this.mockBaseContext()
-        });
+        return EventContext({txn: this.mockBaseContext()});
     }
 
     function mockBaseContext() external view returns (TransactionContext memory) {

--- a/src/utils/ChainsEnumerableMapLib.sol
+++ b/src/utils/ChainsEnumerableMapLib.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {EnumerableMapLib} from "./EnumerableMapLib.sol";
+import {Chains, ChainIdContract, ChainIdAbi} from "../Triggers.sol";
+
+/// @notice Library for managing enumerable maps with Chains enum keys.
+/// @dev Provides convenient wrappers around EnumerableMapLib for Chains enum mappings.
+///
+/// @dev Benefits over regular mappings:
+/// 1. **Iteration Support**: Unlike regular mappings, you can iterate over all keys and values
+/// 2. **Key Enumeration**: Get all keys that have been set with `keys()` function
+/// 3. **Length Tracking**: Know how many entries exist with `length()` function
+/// 4. **Existence Checking**: Reliable `contains()` to check if a key exists
+/// 5. **Index Access**: Access entries by index with `getIndexAt()` function
+/// 6. **Gas Efficient**: Optimized for small to medium sized collections
+///
+/// @dev Usage Examples:
+/// ```solidity
+/// // Declare the map
+/// ChainsEnumerableMapLib.ChainsToChainIdContractMap private contracts;
+/// using ChainsEnumerableMapLib for ChainsEnumerableMapLib.ChainsToChainIdContractMap;
+///
+/// // Add entries
+/// contracts.set(Chains.Ethereum, chainContract(Chains.Ethereum, 0x123...));
+/// contracts.set(Chains.Base, chainContract(Chains.Base, 0x456...));
+///
+/// // Check existence
+/// bool hasEthereumContract = contracts.contains(Chains.Ethereum);
+///
+/// // Get all configured chains
+/// Chains[] memory allChains = contracts.keys();
+///
+/// // Iterate over all entries
+/// for (uint256 i = 0; i < contracts.length(); i++) {
+///     (Chains chain, ChainIdContract memory contract_) = contracts.getAtIndex(i);
+///     // Process each entry...
+/// }
+///
+/// // Remove entries
+/// contracts.remove(Chains.Ethereum);
+/// ```
+library ChainsEnumerableMapLib {
+    /// @dev An enumerable map of `Chains` to `ChainIdContract`.
+    struct ChainsToChainIdContractMap {
+        EnumerableMapLib.Uint8ToChainIdContractMap _inner;
+    }
+
+    /// @dev An enumerable map of `Chains` to `ChainIdAbi`.
+    struct ChainsToChainIdAbiMap {
+        EnumerableMapLib.Uint8ToChainIdAbiMap _inner;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*               CHAINS TO CHAINIDCONTRACT MAP               */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(ChainsToChainIdContractMap storage map, Chains key, ChainIdContract memory value)
+        internal
+        returns (bool)
+    {
+        return EnumerableMapLib.set(map._inner, uint8(key), value);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(ChainsToChainIdContractMap storage map, Chains key, ChainIdContract memory value, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return EnumerableMapLib.set(map._inner, uint8(key), value, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(ChainsToChainIdContractMap storage map, Chains key) internal returns (bool) {
+        return EnumerableMapLib.remove(map._inner, uint8(key));
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(
+        ChainsToChainIdContractMap storage map,
+        Chains key,
+        ChainIdContract memory value,
+        bool isAdd,
+        uint256 cap
+    ) internal returns (bool) {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(ChainsToChainIdContractMap storage map, Chains key) internal view returns (bool) {
+        return EnumerableMapLib.contains(map._inner, uint8(key));
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(ChainsToChainIdContractMap storage map) internal view returns (uint256) {
+        return EnumerableMapLib.length(map._inner);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getAtIndex(ChainsToChainIdContractMap storage map, uint256 i)
+        internal
+        view
+        returns (Chains key, ChainIdContract memory value)
+    {
+        (uint8 rawKey, ChainIdContract memory val) = EnumerableMapLib.getIndexAt(map._inner, i);
+        return (Chains(rawKey), val);
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(ChainsToChainIdContractMap storage map, Chains key)
+        internal
+        view
+        returns (bool exists, ChainIdContract memory value)
+    {
+        return EnumerableMapLib.tryGet(map._inner, uint8(key));
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(ChainsToChainIdContractMap storage map, Chains key)
+        internal
+        view
+        returns (ChainIdContract memory value)
+    {
+        return EnumerableMapLib.get(map._inner, uint8(key));
+    }
+
+    /// @dev Returns the keys as Chains enum values. May run out-of-gas if the map is too big.
+    function keys(ChainsToChainIdContractMap storage map) internal view returns (Chains[] memory result) {
+        uint8[] memory rawKeys = EnumerableMapLib.keys(map._inner);
+        result = new Chains[](rawKeys.length);
+        for (uint256 i = 0; i < rawKeys.length; i++) {
+            result[i] = Chains(rawKeys[i]);
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                 CHAINS TO CHAINIDABI MAP                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(ChainsToChainIdAbiMap storage map, Chains key, ChainIdAbi memory value) internal returns (bool) {
+        return EnumerableMapLib.set(map._inner, uint8(key), value);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(ChainsToChainIdAbiMap storage map, Chains key, ChainIdAbi memory value, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return EnumerableMapLib.set(map._inner, uint8(key), value, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(ChainsToChainIdAbiMap storage map, Chains key) internal returns (bool) {
+        return EnumerableMapLib.remove(map._inner, uint8(key));
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(ChainsToChainIdAbiMap storage map, Chains key, ChainIdAbi memory value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(ChainsToChainIdAbiMap storage map, Chains key) internal view returns (bool) {
+        return EnumerableMapLib.contains(map._inner, uint8(key));
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(ChainsToChainIdAbiMap storage map) internal view returns (uint256) {
+        return EnumerableMapLib.length(map._inner);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getAtIndex(ChainsToChainIdAbiMap storage map, uint256 i)
+        internal
+        view
+        returns (Chains key, ChainIdAbi memory value)
+    {
+        (uint8 rawKey, ChainIdAbi memory val) = EnumerableMapLib.getIndexAt(map._inner, i);
+        return (Chains(rawKey), val);
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(ChainsToChainIdAbiMap storage map, Chains key)
+        internal
+        view
+        returns (bool exists, ChainIdAbi memory value)
+    {
+        return EnumerableMapLib.tryGet(map._inner, uint8(key));
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(ChainsToChainIdAbiMap storage map, Chains key) internal view returns (ChainIdAbi memory value) {
+        return EnumerableMapLib.get(map._inner, uint8(key));
+    }
+
+    /// @dev Returns the keys as Chains enum values. May run out-of-gas if the map is too big.
+    function keys(ChainsToChainIdAbiMap storage map) internal view returns (Chains[] memory result) {
+        uint8[] memory rawKeys = EnumerableMapLib.keys(map._inner);
+        result = new Chains[](rawKeys.length);
+        for (uint256 i = 0; i < rawKeys.length; i++) {
+            result[i] = Chains(rawKeys[i]);
+        }
+    }
+}

--- a/src/utils/EnumerableMapLib.sol
+++ b/src/utils/EnumerableMapLib.sol
@@ -1,0 +1,836 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {EnumerableSetLib} from "./EnumerableSetLib.sol";
+import {ChainIdContract, ChainIdAbi} from "../Triggers.sol";
+
+/// @notice Library for managing enumerable maps in storage.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/EnumerableMapLib.sol)
+/// @author Modified from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableMap.sol)
+library EnumerableMapLib {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CUSTOM ERRORS                        */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The key does not exist in the enumerable map.
+    error EnumerableMapKeyNotFound();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STRUCTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev An enumerable map of `bytes32` to `bytes32`.
+    struct Bytes32ToBytes32Map {
+        EnumerableSetLib.Bytes32Set _keys;
+        mapping(bytes32 => bytes32) _values;
+    }
+
+    /// @dev An enumerable map of `bytes32` to `uint256`.
+    struct Bytes32ToUint256Map {
+        EnumerableSetLib.Bytes32Set _keys;
+        mapping(bytes32 => uint256) _values;
+    }
+
+    /// @dev An enumerable map of `bytes32` to `address`.
+    struct Bytes32ToAddressMap {
+        EnumerableSetLib.Bytes32Set _keys;
+        mapping(bytes32 => address) _values;
+    }
+
+    /// @dev An enumerable map of `uint256` to `bytes32`.
+    struct Uint256ToBytes32Map {
+        EnumerableSetLib.Uint256Set _keys;
+        mapping(uint256 => bytes32) _values;
+    }
+
+    /// @dev An enumerable map of `uint256` to `uint256`.
+    struct Uint256ToUint256Map {
+        EnumerableSetLib.Uint256Set _keys;
+        mapping(uint256 => uint256) _values;
+    }
+
+    /// @dev An enumerable map of `uint256` to `address`.
+    struct Uint256ToAddressMap {
+        EnumerableSetLib.Uint256Set _keys;
+        mapping(uint256 => address) _values;
+    }
+
+    /// @dev An enumerable map of `address` to `bytes32`.
+    struct AddressToBytes32Map {
+        EnumerableSetLib.AddressSet _keys;
+        mapping(address => bytes32) _values;
+    }
+
+    /// @dev An enumerable map of `address` to `uint256`.
+    struct AddressToUint256Map {
+        EnumerableSetLib.AddressSet _keys;
+        mapping(address => uint256) _values;
+    }
+
+    /// @dev An enumerable map of `address` to `address`.
+    struct AddressToAddressMap {
+        EnumerableSetLib.AddressSet _keys;
+        mapping(address => address) _values;
+    }
+
+    /// @dev An enumerable map of `uint8` to `ChainIdContract`.
+    struct Uint8ToChainIdContractMap {
+        EnumerableSetLib.Uint8Set _keys;
+        mapping(uint8 => ChainIdContract) _values;
+    }
+
+    /// @dev An enumerable map of `uint8` to `ChainIdAbi`.
+    struct Uint8ToChainIdAbiMap {
+        EnumerableSetLib.Uint8Set _keys;
+        mapping(uint8 => ChainIdAbi) _values;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     GETTERS / SETTERS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Bytes32ToBytes32Map storage map, bytes32 key, bytes32 value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Bytes32ToBytes32Map storage map, bytes32 key, bytes32 value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Bytes32ToBytes32Map storage map, bytes32 key, bytes32 value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Bytes32ToBytes32Map storage map, bytes32 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Bytes32ToBytes32Map storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Bytes32ToBytes32Map storage map, uint256 i)
+        internal
+        view
+        returns (bytes32 key, bytes32 value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Bytes32ToBytes32Map storage map, bytes32 key) internal view returns (bool exists, bytes32 value) {
+        exists = (value = map._values[key]) != bytes32(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Bytes32ToBytes32Map storage map, bytes32 key) internal view returns (bytes32 value) {
+        if ((value = map._values[key]) == bytes32(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Bytes32ToBytes32Map storage map) internal view returns (bytes32[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Bytes32ToUint256Map storage map, bytes32 key, uint256 value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Bytes32ToUint256Map storage map, bytes32 key, uint256 value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Bytes32ToUint256Map storage map, bytes32 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Bytes32ToUint256Map storage map, bytes32 key, uint256 value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Bytes32ToUint256Map storage map, bytes32 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Bytes32ToUint256Map storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Bytes32ToUint256Map storage map, uint256 i)
+        internal
+        view
+        returns (bytes32 key, uint256 value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Bytes32ToUint256Map storage map, bytes32 key) internal view returns (bool exists, uint256 value) {
+        exists = (value = map._values[key]) != uint256(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Bytes32ToUint256Map storage map, bytes32 key) internal view returns (uint256 value) {
+        if ((value = map._values[key]) == uint256(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Bytes32ToUint256Map storage map) internal view returns (bytes32[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Bytes32ToAddressMap storage map, bytes32 key, address value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Bytes32ToAddressMap storage map, bytes32 key, address value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Bytes32ToAddressMap storage map, bytes32 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Bytes32ToAddressMap storage map, bytes32 key, address value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Bytes32ToAddressMap storage map, bytes32 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Bytes32ToAddressMap storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Bytes32ToAddressMap storage map, uint256 i)
+        internal
+        view
+        returns (bytes32 key, address value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Bytes32ToAddressMap storage map, bytes32 key) internal view returns (bool exists, address value) {
+        exists = (value = map._values[key]) != address(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Bytes32ToAddressMap storage map, bytes32 key) internal view returns (address value) {
+        if ((value = map._values[key]) == address(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Bytes32ToAddressMap storage map) internal view returns (bytes32[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Uint256ToBytes32Map storage map, uint256 key, bytes32 value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Uint256ToBytes32Map storage map, uint256 key, bytes32 value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Uint256ToBytes32Map storage map, uint256 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Uint256ToBytes32Map storage map, uint256 key, bytes32 value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Uint256ToBytes32Map storage map, uint256 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Uint256ToBytes32Map storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint256ToBytes32Map storage map, uint256 i)
+        internal
+        view
+        returns (uint256 key, bytes32 value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Uint256ToBytes32Map storage map, uint256 key) internal view returns (bool exists, bytes32 value) {
+        exists = (value = map._values[key]) != bytes32(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Uint256ToBytes32Map storage map, uint256 key) internal view returns (bytes32 value) {
+        if ((value = map._values[key]) == bytes32(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Uint256ToBytes32Map storage map) internal view returns (uint256[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Uint256ToUint256Map storage map, uint256 key, uint256 value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Uint256ToUint256Map storage map, uint256 key, uint256 value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Uint256ToUint256Map storage map, uint256 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Uint256ToUint256Map storage map, uint256 key, uint256 value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Uint256ToUint256Map storage map, uint256 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Uint256ToUint256Map storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint256ToUint256Map storage map, uint256 i)
+        internal
+        view
+        returns (uint256 key, uint256 value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Uint256ToUint256Map storage map, uint256 key) internal view returns (bool exists, uint256 value) {
+        exists = (value = map._values[key]) != uint256(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Uint256ToUint256Map storage map, uint256 key) internal view returns (uint256 value) {
+        if ((value = map._values[key]) == uint256(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Uint256ToUint256Map storage map) internal view returns (uint256[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Uint256ToAddressMap storage map, uint256 key, address value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Uint256ToAddressMap storage map, uint256 key, address value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Uint256ToAddressMap storage map, uint256 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Uint256ToAddressMap storage map, uint256 key, address value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Uint256ToAddressMap storage map, uint256 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Uint256ToAddressMap storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint256ToAddressMap storage map, uint256 i)
+        internal
+        view
+        returns (uint256 key, address value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Uint256ToAddressMap storage map, uint256 key) internal view returns (bool exists, address value) {
+        exists = (value = map._values[key]) != address(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Uint256ToAddressMap storage map, uint256 key) internal view returns (address value) {
+        if ((value = map._values[key]) == address(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Uint256ToAddressMap storage map) internal view returns (uint256[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(AddressToBytes32Map storage map, address key, bytes32 value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(AddressToBytes32Map storage map, address key, bytes32 value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(AddressToBytes32Map storage map, address key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(AddressToBytes32Map storage map, address key, bytes32 value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(AddressToBytes32Map storage map, address key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(AddressToBytes32Map storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(AddressToBytes32Map storage map, uint256 i)
+        internal
+        view
+        returns (address key, bytes32 value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(AddressToBytes32Map storage map, address key) internal view returns (bool exists, bytes32 value) {
+        exists = (value = map._values[key]) != bytes32(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(AddressToBytes32Map storage map, address key) internal view returns (bytes32 value) {
+        if ((value = map._values[key]) == bytes32(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(AddressToBytes32Map storage map) internal view returns (address[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(AddressToUint256Map storage map, address key, uint256 value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(AddressToUint256Map storage map, address key, uint256 value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(AddressToUint256Map storage map, address key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(AddressToUint256Map storage map, address key, uint256 value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(AddressToUint256Map storage map, address key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(AddressToUint256Map storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(AddressToUint256Map storage map, uint256 i)
+        internal
+        view
+        returns (address key, uint256 value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(AddressToUint256Map storage map, address key) internal view returns (bool exists, uint256 value) {
+        exists = (value = map._values[key]) != uint256(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(AddressToUint256Map storage map, address key) internal view returns (uint256 value) {
+        if ((value = map._values[key]) == uint256(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(AddressToUint256Map storage map) internal view returns (address[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(AddressToAddressMap storage map, address key, address value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(AddressToAddressMap storage map, address key, address value, uint256 cap) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(AddressToAddressMap storage map, address key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(AddressToAddressMap storage map, address key, address value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(AddressToAddressMap storage map, address key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(AddressToAddressMap storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(AddressToAddressMap storage map, uint256 i)
+        internal
+        view
+        returns (address key, address value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(AddressToAddressMap storage map, address key) internal view returns (bool exists, address value) {
+        exists = (value = map._values[key]) != address(0) || contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(AddressToAddressMap storage map, address key) internal view returns (address value) {
+        if ((value = map._values[key]) == address(0)) if (!contains(map, key)) _revertNotFound();
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(AddressToAddressMap storage map) internal view returns (address[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Uint8ToChainIdContractMap storage map, uint8 key, ChainIdContract memory value)
+        internal
+        returns (bool)
+    {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Uint8ToChainIdContractMap storage map, uint8 key, ChainIdContract memory value, uint256 cap)
+        internal
+        returns (bool)
+    {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Uint8ToChainIdContractMap storage map, uint8 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(
+        Uint8ToChainIdContractMap storage map,
+        uint8 key,
+        ChainIdContract memory value,
+        bool isAdd,
+        uint256 cap
+    ) internal returns (bool) {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Uint8ToChainIdContractMap storage map, uint8 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Uint8ToChainIdContractMap storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint8ToChainIdContractMap storage map, uint256 i)
+        internal
+        view
+        returns (uint8 key, ChainIdContract memory value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Uint8ToChainIdContractMap storage map, uint8 key)
+        internal
+        view
+        returns (bool exists, ChainIdContract memory value)
+    {
+        value = map._values[key];
+        exists = contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Uint8ToChainIdContractMap storage map, uint8 key)
+        internal
+        view
+        returns (ChainIdContract memory value)
+    {
+        if (!contains(map, key)) _revertNotFound();
+        value = map._values[key];
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Uint8ToChainIdContractMap storage map) internal view returns (uint8[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    function set(Uint8ToChainIdAbiMap storage map, uint8 key, ChainIdAbi memory value) internal returns (bool) {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key);
+    }
+
+    /// @dev Adds a key-value pair to the map, or updates the value for an existing key.
+    /// Returns true if `key` was added to the map, that is if it was not already present.
+    /// Reverts if the map grows bigger than the custom on-the-fly capacity `cap`.
+    function set(Uint8ToChainIdAbiMap storage map, uint8 key, ChainIdAbi memory value, uint256 cap)
+        internal
+        returns (bool)
+    {
+        map._values[key] = value;
+        return EnumerableSetLib.add(map._keys, key, cap);
+    }
+
+    /// @dev Removes a key-value pair from the map.
+    /// Returns true if `key` was removed from the map, that is if it was present.
+    function remove(Uint8ToChainIdAbiMap storage map, uint8 key) internal returns (bool) {
+        delete map._values[key];
+        return EnumerableSetLib.remove(map._keys, key);
+    }
+
+    /// @dev Shorthand for `isAdd ? map.set(key, value, cap) : map.remove(key)`.
+    function update(Uint8ToChainIdAbiMap storage map, uint8 key, ChainIdAbi memory value, bool isAdd, uint256 cap)
+        internal
+        returns (bool)
+    {
+        return isAdd ? set(map, key, value, cap) : remove(map, key);
+    }
+
+    /// @dev Returns true if the key is in the map.
+    function contains(Uint8ToChainIdAbiMap storage map, uint8 key) internal view returns (bool) {
+        return EnumerableSetLib.contains(map._keys, key);
+    }
+
+    /// @dev Returns the number of key-value pairs in the map.
+    function length(Uint8ToChainIdAbiMap storage map) internal view returns (uint256) {
+        return EnumerableSetLib.length(map._keys);
+    }
+
+    /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint8ToChainIdAbiMap storage map, uint256 i)
+        internal
+        view
+        returns (uint8 key, ChainIdAbi memory value)
+    {
+        value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
+    }
+
+    /// @dev Tries to return the value associated with the key.
+    function tryGet(Uint8ToChainIdAbiMap storage map, uint8 key)
+        internal
+        view
+        returns (bool exists, ChainIdAbi memory value)
+    {
+        value = map._values[key];
+        exists = contains(map, key);
+    }
+
+    /// @dev Returns the value for the key. Reverts if the key is not found.
+    function get(Uint8ToChainIdAbiMap storage map, uint8 key) internal view returns (ChainIdAbi memory value) {
+        if (!contains(map, key)) _revertNotFound();
+        value = map._values[key];
+    }
+
+    /// @dev Returns the keys. May run out-of-gas if the map is too big.
+    function keys(Uint8ToChainIdAbiMap storage map) internal view returns (uint8[] memory) {
+        return EnumerableSetLib.values(map._keys);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      PRIVATE HELPERS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Reverts with `EnumerableMapKeyNotFound()`.
+    function _revertNotFound() private pure {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, 0x88682bf3) // `EnumerableMapKeyNotFound()`.
+            revert(0x1c, 0x04)
+        }
+    }
+}

--- a/src/utils/EnumerableSetLib.sol
+++ b/src/utils/EnumerableSetLib.sol
@@ -1,0 +1,790 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Library for managing enumerable sets in storage.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/EnumerableSetLib.sol)
+///
+/// @dev Note:
+/// In many applications, the number of elements in an enumerable set is small.
+/// This enumerable set implementation avoids storing the length and indices
+/// for up to 3 elements. Once the length exceeds 3 for the first time, the length
+/// and indices will be initialized. The amortized cost of adding elements is O(1).
+///
+/// The AddressSet implementation packs the length with the 0th entry.
+///
+/// All enumerable sets except Uint8Set use a pop and swap mechanism to remove elements.
+/// This means that the iteration order of elements can change between element removals.
+library EnumerableSetLib {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CUSTOM ERRORS                        */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The index must be less than the length.
+    error IndexOutOfBounds();
+
+    /// @dev The value cannot be the zero sentinel.
+    error ValueIsZeroSentinel();
+
+    /// @dev Cannot accommodate a new unique value with the capacity.
+    error ExceedsCapacity();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev A sentinel value to denote the zero value in storage.
+    /// No elements can be equal to this value.
+    /// `uint72(bytes9(keccak256(bytes("_ZERO_SENTINEL"))))`.
+    uint256 private constant _ZERO_SENTINEL = 0xfbb67fda52d4bfb8bf;
+
+    /// @dev The storage layout is given by:
+    /// ```
+    ///     mstore(0x04, _ENUMERABLE_ADDRESS_SET_SLOT_SEED)
+    ///     mstore(0x00, set.slot)
+    ///     let rootSlot := keccak256(0x00, 0x24)
+    ///     mstore(0x20, rootSlot)
+    ///     mstore(0x00, shr(96, shl(96, value)))
+    ///     let positionSlot := keccak256(0x00, 0x40)
+    ///     let valueSlot := add(rootSlot, sload(positionSlot))
+    ///     let valueInStorage := shr(96, sload(valueSlot))
+    ///     let lazyLength := shr(160, shl(160, sload(rootSlot)))
+    /// ```
+    uint256 private constant _ENUMERABLE_ADDRESS_SET_SLOT_SEED = 0x978aab92;
+
+    /// @dev The storage layout is given by:
+    /// ```
+    ///     mstore(0x04, _ENUMERABLE_WORD_SET_SLOT_SEED)
+    ///     mstore(0x00, set.slot)
+    ///     let rootSlot := keccak256(0x00, 0x24)
+    ///     mstore(0x20, rootSlot)
+    ///     mstore(0x00, value)
+    ///     let positionSlot := keccak256(0x00, 0x40)
+    ///     let valueSlot := add(rootSlot, sload(positionSlot))
+    ///     let valueInStorage := sload(valueSlot)
+    ///     let lazyLength := sload(not(rootSlot))
+    /// ```
+    uint256 private constant _ENUMERABLE_WORD_SET_SLOT_SEED = 0x18fb5864;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STRUCTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev An enumerable address set in storage.
+    struct AddressSet {
+        uint256 _spacer;
+    }
+
+    /// @dev An enumerable bytes32 set in storage.
+    struct Bytes32Set {
+        uint256 _spacer;
+    }
+
+    /// @dev An enumerable uint256 set in storage.
+    struct Uint256Set {
+        uint256 _spacer;
+    }
+
+    /// @dev An enumerable int256 set in storage.
+    struct Int256Set {
+        uint256 _spacer;
+    }
+
+    /// @dev An enumerable uint8 set in storage. Useful for enums.
+    struct Uint8Set {
+        uint256 data;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     GETTERS / SETTERS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the number of elements in the set.
+    function length(AddressSet storage set) internal view returns (uint256 result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let rootPacked := sload(rootSlot)
+            let n := shr(160, shl(160, rootPacked))
+            result := shr(1, n)
+            for {} iszero(or(iszero(shr(96, rootPacked)), n)) {} {
+                result := 1
+                if iszero(sload(add(rootSlot, result))) { break }
+                result := 2
+                if iszero(sload(add(rootSlot, result))) { break }
+                result := 3
+                break
+            }
+        }
+    }
+
+    /// @dev Returns the number of elements in the set.
+    function length(Bytes32Set storage set) internal view returns (uint256 result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := sload(not(rootSlot))
+            result := shr(1, n)
+            for {} iszero(n) {} {
+                result := 0
+                if iszero(sload(add(rootSlot, result))) { break }
+                result := 1
+                if iszero(sload(add(rootSlot, result))) { break }
+                result := 2
+                if iszero(sload(add(rootSlot, result))) { break }
+                result := 3
+                break
+            }
+        }
+    }
+
+    /// @dev Returns the number of elements in the set.
+    function length(Uint256Set storage set) internal view returns (uint256 result) {
+        result = length(_toBytes32Set(set));
+    }
+
+    /// @dev Returns the number of elements in the set.
+    function length(Int256Set storage set) internal view returns (uint256 result) {
+        result = length(_toBytes32Set(set));
+    }
+
+    /// @dev Returns the number of elements in the set.
+    function length(Uint8Set storage set) internal view returns (uint256 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            for { let packed := sload(set.slot) } packed { result := add(1, result) } {
+                packed := xor(packed, and(packed, add(1, not(packed))))
+            }
+        }
+    }
+
+    /// @dev Returns whether `value` is in the set.
+    function contains(AddressSet storage set, address value) internal view returns (bool result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            value := shr(96, shl(96, value))
+            if eq(value, _ZERO_SENTINEL) {
+                mstore(0x00, 0xf5a267f1) // `ValueIsZeroSentinel()`.
+                revert(0x1c, 0x04)
+            }
+            if iszero(value) { value := _ZERO_SENTINEL }
+            let rootPacked := sload(rootSlot)
+            for {} 1 {} {
+                if iszero(shr(160, shl(160, rootPacked))) {
+                    result := 1
+                    if eq(shr(96, rootPacked), value) { break }
+                    if eq(shr(96, sload(add(rootSlot, 1))), value) { break }
+                    if eq(shr(96, sload(add(rootSlot, 2))), value) { break }
+                    result := 0
+                    break
+                }
+                mstore(0x20, rootSlot)
+                mstore(0x00, value)
+                result := iszero(iszero(sload(keccak256(0x00, 0x40))))
+                break
+            }
+        }
+    }
+
+    /// @dev Returns whether `value` is in the set.
+    function contains(Bytes32Set storage set, bytes32 value) internal view returns (bool result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            if eq(value, _ZERO_SENTINEL) {
+                mstore(0x00, 0xf5a267f1) // `ValueIsZeroSentinel()`.
+                revert(0x1c, 0x04)
+            }
+            if iszero(value) { value := _ZERO_SENTINEL }
+            for {} 1 {} {
+                if iszero(sload(not(rootSlot))) {
+                    result := 1
+                    if eq(sload(rootSlot), value) { break }
+                    if eq(sload(add(rootSlot, 1)), value) { break }
+                    if eq(sload(add(rootSlot, 2)), value) { break }
+                    result := 0
+                    break
+                }
+                mstore(0x20, rootSlot)
+                mstore(0x00, value)
+                result := iszero(iszero(sload(keccak256(0x00, 0x40))))
+                break
+            }
+        }
+    }
+
+    /// @dev Returns whether `value` is in the set.
+    function contains(Uint256Set storage set, uint256 value) internal view returns (bool result) {
+        result = contains(_toBytes32Set(set), bytes32(value));
+    }
+
+    /// @dev Returns whether `value` is in the set.
+    function contains(Int256Set storage set, int256 value) internal view returns (bool result) {
+        result = contains(_toBytes32Set(set), bytes32(uint256(value)));
+    }
+
+    /// @dev Returns whether `value` is in the set.
+    function contains(Uint8Set storage set, uint8 value) internal view returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := and(1, shr(and(0xff, value), sload(set.slot)))
+        }
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    function add(AddressSet storage set, address value) internal returns (bool result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            value := shr(96, shl(96, value))
+            if eq(value, _ZERO_SENTINEL) {
+                mstore(0x00, 0xf5a267f1) // `ValueIsZeroSentinel()`.
+                revert(0x1c, 0x04)
+            }
+            if iszero(value) { value := _ZERO_SENTINEL }
+            let rootPacked := sload(rootSlot)
+            for { let n := shr(160, shl(160, rootPacked)) } 1 {} {
+                mstore(0x20, rootSlot)
+                if iszero(n) {
+                    let v0 := shr(96, rootPacked)
+                    if iszero(v0) {
+                        sstore(rootSlot, shl(96, value))
+                        result := 1
+                        break
+                    }
+                    if eq(v0, value) { break }
+                    let v1 := shr(96, sload(add(rootSlot, 1)))
+                    if iszero(v1) {
+                        sstore(add(rootSlot, 1), shl(96, value))
+                        result := 1
+                        break
+                    }
+                    if eq(v1, value) { break }
+                    let v2 := shr(96, sload(add(rootSlot, 2)))
+                    if iszero(v2) {
+                        sstore(add(rootSlot, 2), shl(96, value))
+                        result := 1
+                        break
+                    }
+                    if eq(v2, value) { break }
+                    mstore(0x00, v0)
+                    sstore(keccak256(0x00, 0x40), 1)
+                    mstore(0x00, v1)
+                    sstore(keccak256(0x00, 0x40), 2)
+                    mstore(0x00, v2)
+                    sstore(keccak256(0x00, 0x40), 3)
+                    rootPacked := or(rootPacked, 7)
+                    n := 7
+                }
+                mstore(0x00, value)
+                let p := keccak256(0x00, 0x40)
+                if iszero(sload(p)) {
+                    n := shr(1, n)
+                    result := 1
+                    sstore(p, add(1, n))
+                    if iszero(n) {
+                        sstore(rootSlot, or(3, shl(96, value)))
+                        break
+                    }
+                    sstore(add(rootSlot, n), shl(96, value))
+                    sstore(rootSlot, add(2, rootPacked))
+                    break
+                }
+                break
+            }
+        }
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    function add(Bytes32Set storage set, bytes32 value) internal returns (bool result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            if eq(value, _ZERO_SENTINEL) {
+                mstore(0x00, 0xf5a267f1) // `ValueIsZeroSentinel()`.
+                revert(0x1c, 0x04)
+            }
+            if iszero(value) { value := _ZERO_SENTINEL }
+            for { let n := sload(not(rootSlot)) } 1 {} {
+                mstore(0x20, rootSlot)
+                if iszero(n) {
+                    let v0 := sload(rootSlot)
+                    if iszero(v0) {
+                        sstore(rootSlot, value)
+                        result := 1
+                        break
+                    }
+                    if eq(v0, value) { break }
+                    let v1 := sload(add(rootSlot, 1))
+                    if iszero(v1) {
+                        sstore(add(rootSlot, 1), value)
+                        result := 1
+                        break
+                    }
+                    if eq(v1, value) { break }
+                    let v2 := sload(add(rootSlot, 2))
+                    if iszero(v2) {
+                        sstore(add(rootSlot, 2), value)
+                        result := 1
+                        break
+                    }
+                    if eq(v2, value) { break }
+                    mstore(0x00, v0)
+                    sstore(keccak256(0x00, 0x40), 1)
+                    mstore(0x00, v1)
+                    sstore(keccak256(0x00, 0x40), 2)
+                    mstore(0x00, v2)
+                    sstore(keccak256(0x00, 0x40), 3)
+                    n := 7
+                }
+                mstore(0x00, value)
+                let p := keccak256(0x00, 0x40)
+                if iszero(sload(p)) {
+                    n := shr(1, n)
+                    sstore(add(rootSlot, n), value)
+                    sstore(p, add(1, n))
+                    sstore(not(rootSlot), or(1, shl(1, add(1, n))))
+                    result := 1
+                    break
+                }
+                break
+            }
+        }
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    function add(Uint256Set storage set, uint256 value) internal returns (bool result) {
+        result = add(_toBytes32Set(set), bytes32(value));
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    function add(Int256Set storage set, int256 value) internal returns (bool result) {
+        result = add(_toBytes32Set(set), bytes32(uint256(value)));
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    function add(Uint8Set storage set, uint8 value) internal returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := sload(set.slot)
+            let mask := shl(and(0xff, value), 1)
+            sstore(set.slot, or(result, mask))
+            result := iszero(and(result, mask))
+        }
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    /// Reverts if the set grows bigger than the custom on-the-fly capacity `cap`.
+    function add(AddressSet storage set, address value, uint256 cap) internal returns (bool result) {
+        if (result = add(set, value)) if (length(set) > cap) revert ExceedsCapacity();
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    /// Reverts if the set grows bigger than the custom on-the-fly capacity `cap`.
+    function add(Bytes32Set storage set, bytes32 value, uint256 cap) internal returns (bool result) {
+        if (result = add(set, value)) if (length(set) > cap) revert ExceedsCapacity();
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    /// Reverts if the set grows bigger than the custom on-the-fly capacity `cap`.
+    function add(Uint256Set storage set, uint256 value, uint256 cap) internal returns (bool result) {
+        if (result = add(set, value)) if (length(set) > cap) revert ExceedsCapacity();
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    /// Reverts if the set grows bigger than the custom on-the-fly capacity `cap`.
+    function add(Int256Set storage set, int256 value, uint256 cap) internal returns (bool result) {
+        if (result = add(set, value)) if (length(set) > cap) revert ExceedsCapacity();
+    }
+
+    /// @dev Adds `value` to the set. Returns whether `value` was not in the set.
+    /// Reverts if the set grows bigger than the custom on-the-fly capacity `cap`.
+    function add(Uint8Set storage set, uint8 value, uint256 cap) internal returns (bool result) {
+        if (result = add(set, value)) if (length(set) > cap) revert ExceedsCapacity();
+    }
+
+    /// @dev Removes `value` from the set. Returns whether `value` was in the set.
+    function remove(AddressSet storage set, address value) internal returns (bool result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            value := shr(96, shl(96, value))
+            if eq(value, _ZERO_SENTINEL) {
+                mstore(0x00, 0xf5a267f1) // `ValueIsZeroSentinel()`.
+                revert(0x1c, 0x04)
+            }
+            if iszero(value) { value := _ZERO_SENTINEL }
+            let rootPacked := sload(rootSlot)
+            for { let n := shr(160, shl(160, rootPacked)) } 1 {} {
+                if iszero(n) {
+                    result := 1
+                    if eq(shr(96, rootPacked), value) {
+                        sstore(rootSlot, sload(add(rootSlot, 1)))
+                        sstore(add(rootSlot, 1), sload(add(rootSlot, 2)))
+                        sstore(add(rootSlot, 2), 0)
+                        break
+                    }
+                    if eq(shr(96, sload(add(rootSlot, 1))), value) {
+                        sstore(add(rootSlot, 1), sload(add(rootSlot, 2)))
+                        sstore(add(rootSlot, 2), 0)
+                        break
+                    }
+                    if eq(shr(96, sload(add(rootSlot, 2))), value) {
+                        sstore(add(rootSlot, 2), 0)
+                        break
+                    }
+                    result := 0
+                    break
+                }
+                mstore(0x20, rootSlot)
+                mstore(0x00, value)
+                let p := keccak256(0x00, 0x40)
+                let position := sload(p)
+                if iszero(position) { break }
+                n := sub(shr(1, n), 1)
+                if iszero(eq(sub(position, 1), n)) {
+                    let lastValue := shr(96, sload(add(rootSlot, n)))
+                    sstore(add(rootSlot, sub(position, 1)), shl(96, lastValue))
+                    mstore(0x00, lastValue)
+                    sstore(keccak256(0x00, 0x40), position)
+                }
+                sstore(rootSlot, or(shl(96, shr(96, sload(rootSlot))), or(shl(1, n), 1)))
+                sstore(p, 0)
+                result := 1
+                break
+            }
+        }
+    }
+
+    /// @dev Removes `value` from the set. Returns whether `value` was in the set.
+    function remove(Bytes32Set storage set, bytes32 value) internal returns (bool result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            if eq(value, _ZERO_SENTINEL) {
+                mstore(0x00, 0xf5a267f1) // `ValueIsZeroSentinel()`.
+                revert(0x1c, 0x04)
+            }
+            if iszero(value) { value := _ZERO_SENTINEL }
+            for { let n := sload(not(rootSlot)) } 1 {} {
+                if iszero(n) {
+                    result := 1
+                    if eq(sload(rootSlot), value) {
+                        sstore(rootSlot, sload(add(rootSlot, 1)))
+                        sstore(add(rootSlot, 1), sload(add(rootSlot, 2)))
+                        sstore(add(rootSlot, 2), 0)
+                        break
+                    }
+                    if eq(sload(add(rootSlot, 1)), value) {
+                        sstore(add(rootSlot, 1), sload(add(rootSlot, 2)))
+                        sstore(add(rootSlot, 2), 0)
+                        break
+                    }
+                    if eq(sload(add(rootSlot, 2)), value) {
+                        sstore(add(rootSlot, 2), 0)
+                        break
+                    }
+                    result := 0
+                    break
+                }
+                mstore(0x20, rootSlot)
+                mstore(0x00, value)
+                let p := keccak256(0x00, 0x40)
+                let position := sload(p)
+                if iszero(position) { break }
+                n := sub(shr(1, n), 1)
+                if iszero(eq(sub(position, 1), n)) {
+                    let lastValue := sload(add(rootSlot, n))
+                    sstore(add(rootSlot, sub(position, 1)), lastValue)
+                    mstore(0x00, lastValue)
+                    sstore(keccak256(0x00, 0x40), position)
+                }
+                sstore(not(rootSlot), or(shl(1, n), 1))
+                sstore(p, 0)
+                result := 1
+                break
+            }
+        }
+    }
+
+    /// @dev Removes `value` from the set. Returns whether `value` was in the set.
+    function remove(Uint256Set storage set, uint256 value) internal returns (bool result) {
+        result = remove(_toBytes32Set(set), bytes32(value));
+    }
+
+    /// @dev Removes `value` from the set. Returns whether `value` was in the set.
+    function remove(Int256Set storage set, int256 value) internal returns (bool result) {
+        result = remove(_toBytes32Set(set), bytes32(uint256(value)));
+    }
+
+    /// @dev Removes `value` from the set. Returns whether `value` was in the set.
+    function remove(Uint8Set storage set, uint8 value) internal returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := sload(set.slot)
+            let mask := shl(and(0xff, value), 1)
+            sstore(set.slot, and(result, not(mask)))
+            result := iszero(iszero(and(result, mask)))
+        }
+    }
+
+    /// @dev Shorthand for `isAdd ? set.add(value, cap) : set.remove(value)`.
+    function update(AddressSet storage set, address value, bool isAdd, uint256 cap) internal returns (bool) {
+        return isAdd ? add(set, value, cap) : remove(set, value);
+    }
+
+    /// @dev Shorthand for `isAdd ? set.add(value, cap) : set.remove(value)`.
+    function update(Bytes32Set storage set, bytes32 value, bool isAdd, uint256 cap) internal returns (bool) {
+        return isAdd ? add(set, value, cap) : remove(set, value);
+    }
+
+    /// @dev Shorthand for `isAdd ? set.add(value, cap) : set.remove(value)`.
+    function update(Uint256Set storage set, uint256 value, bool isAdd, uint256 cap) internal returns (bool) {
+        return isAdd ? add(set, value, cap) : remove(set, value);
+    }
+
+    /// @dev Shorthand for `isAdd ? set.add(value, cap) : set.remove(value)`.
+    function update(Int256Set storage set, int256 value, bool isAdd, uint256 cap) internal returns (bool) {
+        return isAdd ? add(set, value, cap) : remove(set, value);
+    }
+
+    /// @dev Shorthand for `isAdd ? set.add(value, cap) : set.remove(value)`.
+    function update(Uint8Set storage set, uint8 value, bool isAdd, uint256 cap) internal returns (bool) {
+        return isAdd ? add(set, value, cap) : remove(set, value);
+    }
+
+    /// @dev Returns all of the values in the set.
+    /// Note: This can consume more gas than the block gas limit for large sets.
+    function values(AddressSet storage set) internal view returns (address[] memory result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let zs := _ZERO_SENTINEL
+            let rootPacked := sload(rootSlot)
+            let n := shr(160, shl(160, rootPacked))
+            result := mload(0x40)
+            let o := add(0x20, result)
+            let v := shr(96, rootPacked)
+            mstore(o, mul(v, iszero(eq(v, zs))))
+            for {} 1 {} {
+                if iszero(n) {
+                    if v {
+                        n := 1
+                        v := shr(96, sload(add(rootSlot, n)))
+                        if v {
+                            n := 2
+                            mstore(add(o, 0x20), mul(v, iszero(eq(v, zs))))
+                            v := shr(96, sload(add(rootSlot, n)))
+                            if v {
+                                n := 3
+                                mstore(add(o, 0x40), mul(v, iszero(eq(v, zs))))
+                            }
+                        }
+                    }
+                    break
+                }
+                n := shr(1, n)
+                for { let i := 1 } lt(i, n) { i := add(i, 1) } {
+                    v := shr(96, sload(add(rootSlot, i)))
+                    mstore(add(o, shl(5, i)), mul(v, iszero(eq(v, zs))))
+                }
+                break
+            }
+            mstore(result, n)
+            mstore(0x40, add(o, shl(5, n)))
+        }
+    }
+
+    /// @dev Returns all of the values in the set.
+    /// Note: This can consume more gas than the block gas limit for large sets.
+    function values(Bytes32Set storage set) internal view returns (bytes32[] memory result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let zs := _ZERO_SENTINEL
+            let n := sload(not(rootSlot))
+            result := mload(0x40)
+            let o := add(0x20, result)
+            for {} 1 {} {
+                if iszero(n) {
+                    let v := sload(rootSlot)
+                    if v {
+                        n := 1
+                        mstore(o, mul(v, iszero(eq(v, zs))))
+                        v := sload(add(rootSlot, n))
+                        if v {
+                            n := 2
+                            mstore(add(o, 0x20), mul(v, iszero(eq(v, zs))))
+                            v := sload(add(rootSlot, n))
+                            if v {
+                                n := 3
+                                mstore(add(o, 0x40), mul(v, iszero(eq(v, zs))))
+                            }
+                        }
+                    }
+                    break
+                }
+                n := shr(1, n)
+                for { let i := 0 } lt(i, n) { i := add(i, 1) } {
+                    let v := sload(add(rootSlot, i))
+                    mstore(add(o, shl(5, i)), mul(v, iszero(eq(v, zs))))
+                }
+                break
+            }
+            mstore(result, n)
+            mstore(0x40, add(o, shl(5, n)))
+        }
+    }
+
+    /// @dev Returns all of the values in the set.
+    /// Note: This can consume more gas than the block gas limit for large sets.
+    function values(Uint256Set storage set) internal view returns (uint256[] memory result) {
+        result = _toUints(values(_toBytes32Set(set)));
+    }
+
+    /// @dev Returns all of the values in the set.
+    /// Note: This can consume more gas than the block gas limit for large sets.
+    function values(Int256Set storage set) internal view returns (int256[] memory result) {
+        result = _toInts(values(_toBytes32Set(set)));
+    }
+
+    /// @dev Returns all of the values in the set.
+    function values(Uint8Set storage set) internal view returns (uint8[] memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let ptr := add(result, 0x20)
+            let o := 0
+            for { let packed := sload(set.slot) } packed {} {
+                if iszero(and(packed, 0xffff)) {
+                    o := add(o, 16)
+                    packed := shr(16, packed)
+                    continue
+                }
+                mstore(ptr, o)
+                ptr := add(ptr, shl(5, and(packed, 1)))
+                o := add(o, 1)
+                packed := shr(1, packed)
+            }
+            mstore(result, shr(5, sub(ptr, add(result, 0x20))))
+            mstore(0x40, ptr)
+        }
+    }
+
+    /// @dev Returns the element at index `i` in the set. Reverts if `i` is out-of-bounds.
+    function getIndexAt(AddressSet storage set, uint256 i) internal view returns (address result) {
+        bytes32 rootSlot = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := shr(96, sload(add(rootSlot, i)))
+            result := mul(result, iszero(eq(result, _ZERO_SENTINEL)))
+        }
+        if (i >= length(set)) revert IndexOutOfBounds();
+    }
+
+    /// @dev Returns the element at index `i` in the set. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Bytes32Set storage set, uint256 i) internal view returns (bytes32 result) {
+        result = _rootSlot(set);
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := sload(add(result, i))
+            result := mul(result, iszero(eq(result, _ZERO_SENTINEL)))
+        }
+        if (i >= length(set)) revert IndexOutOfBounds();
+    }
+
+    /// @dev Returns the element at index `i` in the set. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint256Set storage set, uint256 i) internal view returns (uint256 result) {
+        result = uint256(getIndexAt(_toBytes32Set(set), i));
+    }
+
+    /// @dev Returns the element at index `i` in the set. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Int256Set storage set, uint256 i) internal view returns (int256 result) {
+        result = int256(uint256(getIndexAt(_toBytes32Set(set), i)));
+    }
+
+    /// @dev Returns the element at index `i` in the set. Reverts if `i` is out-of-bounds.
+    function getIndexAt(Uint8Set storage set, uint256 i) internal view returns (uint8 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let packed := sload(set.slot)
+            for {} 1 {
+                mstore(0x00, 0x4e23d035) // `IndexOutOfBounds()`.
+                revert(0x1c, 0x04)
+            } {
+                if iszero(lt(i, 256)) { continue }
+                for { let j := 0 } iszero(eq(i, j)) {} {
+                    packed := xor(packed, and(packed, add(1, not(packed))))
+                    j := add(j, 1)
+                }
+                if iszero(packed) { continue }
+                break
+            }
+            // Find first set subroutine, optimized for smaller bytecode size.
+            let x := and(packed, add(1, not(packed)))
+            let r := shl(7, iszero(iszero(shr(128, x))))
+            r := or(r, shl(6, iszero(iszero(shr(64, shr(r, x))))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            // For the lower 5 bits of the result, use a De Bruijn lookup.
+            // forgefmt: disable-next-item
+            result := or(r, byte(and(div(0xd76453e0, shr(r, x)), 0x1f),
+                0x001f0d1e100c1d070f090b19131c1706010e11080a1a141802121b1503160405))
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      PRIVATE HELPERS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the root slot.
+    function _rootSlot(AddressSet storage s) private pure returns (bytes32 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x04, _ENUMERABLE_ADDRESS_SET_SLOT_SEED)
+            mstore(0x00, s.slot)
+            r := keccak256(0x00, 0x24)
+        }
+    }
+
+    /// @dev Returns the root slot.
+    function _rootSlot(Bytes32Set storage s) private pure returns (bytes32 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x04, _ENUMERABLE_WORD_SET_SLOT_SEED)
+            mstore(0x00, s.slot)
+            r := keccak256(0x00, 0x24)
+        }
+    }
+
+    /// @dev Casts to a Bytes32Set.
+    function _toBytes32Set(Uint256Set storage s) private pure returns (Bytes32Set storage c) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            c.slot := s.slot
+        }
+    }
+
+    /// @dev Casts to a Bytes32Set.
+    function _toBytes32Set(Int256Set storage s) private pure returns (Bytes32Set storage c) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            c.slot := s.slot
+        }
+    }
+
+    /// @dev Casts to a uint256 array.
+    function _toUints(bytes32[] memory a) private pure returns (uint256[] memory c) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            c := a
+        }
+    }
+
+    /// @dev Casts to a int256 array.
+    function _toInts(bytes32[] memory a) private pure returns (int256[] memory c) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            c := a
+        }
+    }
+}


### PR DESCRIPTION
- add `ProtocolTriggers.sol` as an extension to `BaseTriggers`

The idea would be to use it like [here](https://github.com/duneanalytics/sim-idx-dex-trades/blob/main/listeners/src/Main.sol).
This will alleviate some of the burden of defining triggers from multiple protocols and multiple chains.