### PR TITLE
Add transaction and log index

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ libs = ["lib"]
 exclude_lints = ["unaliased-plain-import"]
 
 [rpc_endpoints]
-arbitrum="https://arb1.arbitrum.io/rpc"
+arbitrum="https://arb1.lava.build"
 ethereum="https://eth.llamarpc.com"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -86,7 +86,7 @@ struct TransactionContext {
     uint256 chainId;
     /// @notice Function that returns the transaction index in the block
     /// @dev The position of the transaction in the block
-    function() external returns (uint256) transactionIndex;
+    function() external returns (uint64) transactionIndex;
 }
 
 // @noticed Special functions for state access
@@ -132,7 +132,7 @@ struct EventContext {
     bool isDecodingSuccessful;
     /// @notice Function that returns the log index in the block
     /// @dev The position of the log entry in the block
-    function() external returns (uint256) logIndex;
+    function() external returns (uint64) logIndex;
 }
 
 /// @notice Context provided to pre-function triggers
@@ -205,7 +205,7 @@ struct RawLogContext {
     function() external returns (uint120) globalIndex;
     /// @notice Function that returns the log index in the block
     /// @dev The position of the log entry in the block
-    function() external returns (uint256) logIndex;
+    function() external returns (uint64) logIndex;
 }
 
 /// @notice Context provided to block-based triggers

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -84,6 +84,9 @@ struct TransactionContext {
     /// @notice The blockchain network identifier
     /// @dev Chain ID as defined in EIP-155
     uint256 chainId;
+    /// @notice Function that returns the transaction index in the block
+    /// @dev The position of the transaction in the block
+    function () external returns (uint256) transactionIndex;
 }
 
 // @noticed Special functions for state access
@@ -127,6 +130,9 @@ struct EventContext {
     // @notice Whether the event log was decoded successfully
     // @dev If the event log was decoded successfully, this will be true
     bool isDecodingSuccessful;
+    /// @notice Function that returns the log index in the block
+    /// @dev The position of the log entry in the block
+    function () external returns (uint256) logIndex;
 }
 
 /// @notice Context provided to pre-function triggers
@@ -197,6 +203,9 @@ struct RawLogContext {
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
     function () external returns (uint120) globalIndex;
+    /// @notice Function that returns the log index in the block
+    /// @dev The position of the log entry in the block
+    function () external returns (uint256) logIndex;
 }
 
 /// @notice Context provided to block-based triggers

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -42,28 +42,28 @@ enum CallType {
 struct CallFrame {
     /// @notice Function that returns the address of the currently executing contract
     /// @dev The contract whose code is currently being executed
-    function () external returns (address) callee;
+    function() external returns (address) callee;
     /// @notice Function that returns the address that initiated the current call
     /// @dev Could be an EOA or another contract
-    function () external returns (address) caller;
+    function() external returns (address) caller;
     /// @notice Function that returns the address that delegated the current call
     /// @dev Relevant for proxy patterns where execution is delegated
-    function () external returns (address) delegator;
+    function() external returns (address) delegator;
     /// @notice Function that returns the address of the implementation contract
     /// @dev The contract that contains the actual implementation code
-    function () external returns (address) delegatee;
+    function() external returns (address) delegatee;
     /// @notice Function that returns the calldata for the current call
     /// @dev The input data sent with the transaction or call
-    function () external returns (bytes memory) callData;
+    function() external returns (bytes memory) callData;
     /// @notice Function that returns the current call depth
     /// @dev How many levels deep the current call is in the call stack
-    function () external returns (uint256) callDepth;
+    function() external returns (uint256) callDepth;
     /// @notice Function that returns the value transferred with the call
     /// @dev Amount of wei sent with the call
-    function () external returns (uint256) value;
+    function() external returns (uint256) value;
     /// @notice Function that returns the type of the current call
     /// @dev One of the CallType enum values
-    function () external returns (CallType) callType;
+    function() external returns (CallType) callType;
     /// @notice The method used to verify this contract for indexing
     /// @dev Determines how the contract's functionality was identified
     ContractVerificationSource verificationSource;
@@ -77,16 +77,16 @@ struct TransactionContext {
     CallFrame call;
     /// @notice Function that returns whether the transaction succeeded
     /// @dev True if the transaction completed without reverting
-    function () external returns (bool) isSuccessful;
+    function() external returns (bool) isSuccessful;
     /// @notice Function that returns the transaction hash
     /// @dev The unique identifier for this transaction
-    function () external returns (bytes32) hash;
+    function() external returns (bytes32) hash;
     /// @notice The blockchain network identifier
     /// @dev Chain ID as defined in EIP-155
     uint256 chainId;
     /// @notice Function that returns the transaction index in the block
     /// @dev The position of the transaction in the block
-    function () external returns (uint256) transactionIndex;
+    function() external returns (uint256) transactionIndex;
 }
 
 // @noticed Special functions for state access
@@ -107,7 +107,7 @@ struct FunctionContext {
     SimFunctions sim;
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
-    function () external returns (uint120) globalIndex;
+    function() external returns (uint120) globalIndex;
     // @notice Whether the function call input was decoded successfully
     // @dev If the function call input was decoded successfully, this will be true
     bool isInputDecodingSuccessful;
@@ -126,13 +126,13 @@ struct EventContext {
     SimFunctions sim;
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
-    function () external returns (uint120) globalIndex;
+    function() external returns (uint120) globalIndex;
     // @notice Whether the event log was decoded successfully
     // @dev If the event log was decoded successfully, this will be true
     bool isDecodingSuccessful;
     /// @notice Function that returns the log index in the block
     /// @dev The position of the log entry in the block
-    function () external returns (uint256) logIndex;
+    function() external returns (uint256) logIndex;
 }
 
 /// @notice Context provided to pre-function triggers
@@ -145,7 +145,7 @@ struct PreFunctionContext {
     SimFunctions sim;
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
-    function () external returns (uint120) globalIndex;
+    function() external returns (uint120) globalIndex;
     // @notice Whether the function call input was decoded successfully
     // @dev If the function call input was decoded successfully, this will be true
     bool isInputDecodingSuccessful;
@@ -161,13 +161,13 @@ struct RawCallContext {
     SimFunctions sim;
     /// @notice Function that returns the raw calldata
     /// @dev The complete input data for the call
-    function () external returns (bytes memory) callData;
+    function() external returns (bytes memory) callData;
     /// @notice Function that returns the raw return data
     /// @dev The complete output data from the call
-    function () external returns (bytes memory) returnData;
+    function() external returns (bytes memory) returnData;
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
-    function () external returns (uint120) globalIndex;
+    function() external returns (uint120) globalIndex;
 }
 
 /// @notice Context provided to raw pre-call triggers
@@ -180,10 +180,10 @@ struct RawPreCallContext {
     SimFunctions sim;
     /// @notice Function that returns the raw calldata
     /// @dev The complete input data for the upcoming call
-    function () external returns (bytes memory) callData;
+    function() external returns (bytes memory) callData;
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
-    function () external returns (uint120) globalIndex;
+    function() external returns (uint120) globalIndex;
 }
 
 /// @notice Context provided to raw log triggers
@@ -196,16 +196,16 @@ struct RawLogContext {
     SimFunctions sim;
     /// @notice Function that returns the log topics
     /// @dev Array of indexed event parameters (topics 0-3)
-    function () external returns (bytes32[] memory) topics;
+    function() external returns (bytes32[] memory) topics;
     /// @notice Function that returns the log data
     /// @dev The non-indexed event data
-    function () external returns (bytes memory) data;
+    function() external returns (bytes memory) data;
     /// @notice The global index of the current execution
     /// @dev A unique identifier that orders blockchain events globally
-    function () external returns (uint120) globalIndex;
+    function() external returns (uint120) globalIndex;
     /// @notice Function that returns the log index in the block
     /// @dev The position of the log entry in the block
-    function () external returns (uint256) logIndex;
+    function() external returns (uint256) logIndex;
 }
 
 /// @notice Context provided to block-based triggers

--- a/src/Triggers.sol
+++ b/src/Triggers.sol
@@ -99,11 +99,10 @@ struct ContractTarget {
 /// @param contractAddress The contract address on the specified chain
 /// @return A ChainIdContract with full block range coverage
 function chainContract(Chains chain, address contractAddress) pure returns (ChainIdContract memory) {
-    return ChainIdContract({
-        chainId: chainToChainId(chain),
-        contractAddress: contractAddress,
-        blockRange: blockRangeFull()
-    });
+    return
+        ChainIdContract({
+            chainId: chainToChainId(chain), contractAddress: contractAddress, blockRange: blockRangeFull()
+        });
 }
 
 /// @notice Creates a ChainIdContract from a ChainWithRange and contract address

--- a/src/libs/BlockRange.sol
+++ b/src/libs/BlockRange.sol
@@ -41,11 +41,7 @@ library BlockRangeLib {
     /// @param range The existing block range to modify
     /// @param endBlockInclusive The ending block number (inclusive)
     /// @return The modified BlockRange with kind set to RangeInclusive
-    function withEndBlock(BlockRange memory range, uint64 endBlockInclusive)
-        internal
-        pure
-        returns (BlockRange memory)
-    {
+    function withEndBlock(BlockRange memory range, uint64 endBlockInclusive) internal pure returns (BlockRange memory) {
         range.endBlockInclusive = endBlockInclusive;
         range.kind = BlockRangeKind.RangeInclusive;
         return range;

--- a/src/libs/Chains.sol
+++ b/src/libs/Chains.sol
@@ -101,10 +101,10 @@ library ChainsLib {
     /// @param startBlockInclusive The starting block number (inclusive)
     /// @return A ChainWithRange configured from the specified block
     function withStartBlock(Chains chain, uint64 startBlockInclusive) internal pure returns (ChainWithRange memory) {
-        return ChainWithRange({
-            chainId: chainToChainId(chain),
-            blockRange: BlockRangeLib.withStartBlock(startBlockInclusive)
-        });
+        return
+            ChainWithRange({
+                chainId: chainToChainId(chain), blockRange: BlockRangeLib.withStartBlock(startBlockInclusive)
+            });
     }
 
     /// @notice Adds an end block to an existing chain configuration

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -24,8 +24,8 @@ contract MockContexts {
     bytes32 public hash;
     bool public isSuccessful;
     uint120 private indexValue;
-    uint256 public transactionIndex;
-    uint256 public logIndex;
+    uint64 public transactionIndex;
+    uint64 public logIndex;
 
     function mockGlobalIndex() external view returns (uint120) {
         return indexValue;
@@ -134,12 +134,12 @@ contract MockContexts {
         return address(0);
     }
 
-    function withTransactionIndex(uint256 _transactionIndex) external returns (MockContexts) {
+    function withTransactionIndex(uint64 _transactionIndex) external returns (MockContexts) {
         transactionIndex = _transactionIndex;
         return this;
     }
 
-    function withLogIndex(uint256 _logIndex) external returns (MockContexts) {
+    function withLogIndex(uint64 _logIndex) external returns (MockContexts) {
         logIndex = _logIndex;
         return this;
     }

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -24,6 +24,8 @@ contract MockContexts {
     bytes32 public hash;
     bool public isSuccessful;
     uint120 private indexValue;
+    uint256 public transactionIndex;
+    uint256 public logIndex;
 
     function mockGlobalIndex() external view returns (uint120) {
         return indexValue;
@@ -49,7 +51,8 @@ contract MockContexts {
             txn: this.mockBaseContext(),
             globalIndex: this.mockGlobalIndex,
             sim: this.mockSimFunctions(),
-            isDecodingSuccessful: true
+            isDecodingSuccessful: true,
+            logIndex: this.logIndex
         });
     }
 
@@ -58,7 +61,8 @@ contract MockContexts {
             call: this.mockCallFrame(),
             hash: this.hash,
             isSuccessful: this.isSuccessful,
-            chainId: 1
+            chainId: 1,
+            transactionIndex: this.transactionIndex
         });
     }
 
@@ -128,5 +132,15 @@ contract MockContexts {
 
     function getDeployer(address) external pure returns (address) {
         return address(0);
+    }
+
+    function withTransactionIndex(uint256 _transactionIndex) external returns (MockContexts) {
+        transactionIndex = _transactionIndex;
+        return this;
+    }
+
+    function withLogIndex(uint256 _logIndex) external returns (MockContexts) {
+        logIndex = _logIndex;
+        return this;
     }
 }

--- a/src/utils/EnumerableMapLib.sol
+++ b/src/utils/EnumerableMapLib.sol
@@ -130,11 +130,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(Bytes32ToBytes32Map storage map, uint256 i)
-        internal
-        view
-        returns (bytes32 key, bytes32 value)
-    {
+    function getIndexAt(Bytes32ToBytes32Map storage map, uint256 i) internal view returns (bytes32 key, bytes32 value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -194,11 +190,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(Bytes32ToUint256Map storage map, uint256 i)
-        internal
-        view
-        returns (bytes32 key, uint256 value)
-    {
+    function getIndexAt(Bytes32ToUint256Map storage map, uint256 i) internal view returns (bytes32 key, uint256 value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -258,11 +250,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(Bytes32ToAddressMap storage map, uint256 i)
-        internal
-        view
-        returns (bytes32 key, address value)
-    {
+    function getIndexAt(Bytes32ToAddressMap storage map, uint256 i) internal view returns (bytes32 key, address value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -322,11 +310,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(Uint256ToBytes32Map storage map, uint256 i)
-        internal
-        view
-        returns (uint256 key, bytes32 value)
-    {
+    function getIndexAt(Uint256ToBytes32Map storage map, uint256 i) internal view returns (uint256 key, bytes32 value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -386,11 +370,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(Uint256ToUint256Map storage map, uint256 i)
-        internal
-        view
-        returns (uint256 key, uint256 value)
-    {
+    function getIndexAt(Uint256ToUint256Map storage map, uint256 i) internal view returns (uint256 key, uint256 value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -450,11 +430,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(Uint256ToAddressMap storage map, uint256 i)
-        internal
-        view
-        returns (uint256 key, address value)
-    {
+    function getIndexAt(Uint256ToAddressMap storage map, uint256 i) internal view returns (uint256 key, address value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -514,11 +490,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(AddressToBytes32Map storage map, uint256 i)
-        internal
-        view
-        returns (address key, bytes32 value)
-    {
+    function getIndexAt(AddressToBytes32Map storage map, uint256 i) internal view returns (address key, bytes32 value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -578,11 +550,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(AddressToUint256Map storage map, uint256 i)
-        internal
-        view
-        returns (address key, uint256 value)
-    {
+    function getIndexAt(AddressToUint256Map storage map, uint256 i) internal view returns (address key, uint256 value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 
@@ -642,11 +610,7 @@ library EnumerableMapLib {
     }
 
     /// @dev Returns the key-value pair at index `i`. Reverts if `i` is out-of-bounds.
-    function getIndexAt(AddressToAddressMap storage map, uint256 i)
-        internal
-        view
-        returns (address key, address value)
-    {
+    function getIndexAt(AddressToAddressMap storage map, uint256 i) internal view returns (address key, address value) {
         value = map._values[key = EnumerableSetLib.getIndexAt(map._keys, i)];
     }
 

--- a/test/Env.t.sol
+++ b/test/Env.t.sol
@@ -16,17 +16,17 @@ contract EnvTest is Test {
         vm.selectFork(chainIdToForkId[1]);
         assertEq(vm.activeFork(), chainIdToForkId[1]);
 
-        vm.rollFork(20000000);
-        assertEq(block.number, 20000000);
-        assertEq(blockNumber(), 20000000);
+        vm.rollFork(23583017);
+        assertEq(block.number, 23583017);
+        assertEq(blockNumber(), 23583017);
     }
 
     function test_blockNumber_arbitrum() public {
         vm.selectFork(chainIdToForkId[42161]);
         assertEq(vm.activeFork(), chainIdToForkId[42161]);
 
-        vm.rollFork(372169557);
-        assertEq(block.number, 23218710);
+        vm.rollFork(389783281);
+        assertEq(block.number, 23583003);
         // should revert with no data because foundry doesn't support the arbsys precompiles
         vm.expectRevert(bytes(""), address(ARB_SYS_ADDRESS));
         blockNumber();

--- a/test/GlobalIndex.t.sol
+++ b/test/GlobalIndex.t.sol
@@ -13,7 +13,8 @@ contract GlobalIndexTest is Test {
 
     function test_GlobalIndex() public pure {
         // Create a global index
-        uint120 index = (uint120(BLOCK_NUMBER) << 88) | (uint120(REORG_INCARNATION) << 64) | (uint120(TXN_INDEX) << 40)
+        uint120 index =
+            (uint120(BLOCK_NUMBER) << 88) | (uint120(REORG_INCARNATION) << 64) | (uint120(TXN_INDEX) << 40)
             | uint120(SHADOW_PC);
         assertEq(index, 1329227995784915872903807060280344575, "Global index computation incorrect");
 


### PR DESCRIPTION
Towards IDX-984

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `transactionIndex` and `logIndex` accessors to context types, updates mocks/tests accordingly, and switches the Arbitrum RPC endpoint.
> 
> - **Context API**:
>   - `TransactionContext`: add `function() external returns (uint64) transactionIndex`.
>   - `EventContext` and `RawLogContext`: add `function() external returns (uint64) logIndex`.
> - **Mocks/Tests**:
>   - `src/test/MockContexts.sol`: store/expose `transactionIndex` and `logIndex`; include in `mockBaseContext`/`mockEventContext`; add `withTransactionIndex` and `withLogIndex`.
>   - `test/Env.t.sol`: update fork roll targets and expected block numbers for Ethereum and Arbitrum.
> - **Config**:
>   - `foundry.toml`: change Arbitrum RPC to `https://arb1.lava.build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6db8a235aaf289b504561fa0ba4dc4bf7c89a5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->