### PR TITLE
Chains: Add Gnosis

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,5 +9,6 @@ exclude_lints = ["unaliased-plain-import"]
 [rpc_endpoints]
 arbitrum="https://arb1.lava.build"
 ethereum="https://eth.llamarpc.com"
+gnosis="https://rpc.gnosis.gateway.fm"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/libs/Chains.sol
+++ b/src/libs/Chains.sol
@@ -33,7 +33,9 @@ enum Chains {
     /// @dev Arbitrum One (Chain ID: 42161)
     Arbitrum,
     /// @dev Optimism Mainnet (Chain ID: 10)
-    Optimism
+    Optimism,
+    /// @dev Gnosis (Chain ID: 100)
+    Gnosis
 }
 
 using ChainsLib for Chains global;
@@ -57,12 +59,13 @@ function chainToChainId(Chains chain) pure returns (uint256) {
     if (chain == Chains.Shape) return 360;
     if (chain == Chains.Arbitrum) return 42161;
     if (chain == Chains.Optimism) return 10;
+    if (chain == Chains.Gnosis) return 100;
     revert("Unsupported chain");
 }
 
 /// @notice Returns all supported chains
 /// @return An array of all supported chains
-function allSupportedChains() pure returns (Chains[14] memory) {
+function allSupportedChains() pure returns (Chains[15] memory) {
     return [
         Chains.Ethereum,
         Chains.EthereumSepolia,
@@ -77,7 +80,8 @@ function allSupportedChains() pure returns (Chains[14] memory) {
         Chains.Soneium,
         Chains.Shape,
         Chains.Arbitrum,
-        Chains.Optimism
+        Chains.Optimism,
+        Chains.Gnosis
     ];
 }
 

--- a/src/libs/NativeToken.sol
+++ b/src/libs/NativeToken.sol
@@ -31,6 +31,7 @@ library NativeTokenLib {
         if (chainId == chainToChainId(Chains.Shape)) return NativeToken("Ether", "ETH", 18);
         if (chainId == chainToChainId(Chains.Arbitrum)) return NativeToken("Ether", "ETH", 18);
         if (chainId == chainToChainId(Chains.Optimism)) return NativeToken("Ether", "ETH", 18);
+        if (chainId == chainToChainId(Chains.Gnosis)) return NativeToken("xDAI", "xDAI", 18);
         revert("Unsupported chain");
     }
 }

--- a/test/Env.t.sol
+++ b/test/Env.t.sol
@@ -10,6 +10,7 @@ contract EnvTest is Test {
     function setUp() public {
         chainIdToForkId[1] = vm.createFork(vm.rpcUrl("ethereum"));
         chainIdToForkId[42161] = vm.createFork(vm.rpcUrl("arbitrum"));
+        chainIdToForkId[100] = vm.createFork(vm.rpcUrl("gnosis"));
     }
 
     function test_blockNumber() public {
@@ -30,5 +31,14 @@ contract EnvTest is Test {
         // should revert with no data because foundry doesn't support the arbsys precompiles
         vm.expectRevert(bytes(""), address(ARB_SYS_ADDRESS));
         blockNumber();
+    }
+
+    function test_blockNumber_gnosis() public {
+        vm.selectFork(chainIdToForkId[100]);
+        assertEq(vm.activeFork(), chainIdToForkId[100]);
+
+        vm.rollFork(23583017);
+        assertEq(block.number, 23583017);
+        assertEq(blockNumber(), 23583017);
     }
 }

--- a/test/GlobalIndex.t.sol
+++ b/test/GlobalIndex.t.sol
@@ -13,8 +13,7 @@ contract GlobalIndexTest is Test {
 
     function test_GlobalIndex() public pure {
         // Create a global index
-        uint120 index =
-            (uint120(BLOCK_NUMBER) << 88) | (uint120(REORG_INCARNATION) << 64) | (uint120(TXN_INDEX) << 40)
+        uint120 index = (uint120(BLOCK_NUMBER) << 88) | (uint120(REORG_INCARNATION) << 64) | (uint120(TXN_INDEX) << 40)
             | uint120(SHADOW_PC);
         assertEq(index, 1329227995784915872903807060280344575, "Global index computation incorrect");
 

--- a/test/NativeToken.t.sol
+++ b/test/NativeToken.t.sol
@@ -8,9 +8,15 @@ import {Chains, chainToChainId, allSupportedChains} from "../src/libs/Chains.sol
 contract NativeTokenTest is Test {
     function test_withChainId() public pure {
         for (uint256 i = 0; i < allSupportedChains().length; i++) {
-            NativeToken memory token = NativeTokenLib.withChainId(chainToChainId(allSupportedChains()[i]));
-            assertEq(token.name, "Ether");
-            assertEq(token.symbol, "ETH");
+            uint256 chainId = chainToChainId(allSupportedChains()[i]);
+            NativeToken memory token = NativeTokenLib.withChainId(chainId);
+            if (chainId == 100) {
+                assertEq(token.name, "xDAI");
+                assertEq(token.symbol, "xDAI");
+            } else {
+                assertEq(token.name, "Ether");
+                assertEq(token.symbol, "ETH");
+            }
             assertEq(token.decimals, 18);
         }
     }


### PR DESCRIPTION
While trying to test-drive an idx project on Gnosis Chain, I was hitting a few expected errors (i.e. chain not supported).

Namely:

```
$ sim listeners evaluate --start-block 41149803 --chain-id 100

> ERROR cli: Error (2defe879a4519ca4d654e8410bf516ff): Internal: TestListener: failed to test listener: rpc error: code = Internal desc = rpc error: code = Internal desc = failed to send probe to iEVM: failed to dispatch ad hoc probe: failed to execute probe: rpc error: code = Internal desc = Internal error: Chain config not found for chain id 100
```

It was a bit difficult to tell if all requirements were met to add a new chain (components feel disjoint).

I wonder if it might be nice to allow users to provide their own RPCs on [sim listeners evaluate](https://docs.sim.dune.com/idx/cli#sim-listeners-evaluate) command



If this actually works out, one could probably add polygon in a similar way... although their native asset has some weird caveats.