### PR TITLE
Add sim SQL functions to SimFunctions

### DIFF
--- a/src/Context.sol
+++ b/src/Context.sol
@@ -101,39 +101,39 @@ struct SimFunctions {
     ///         position of the parameter. For example, $1 is the first parameter,
     ///         $2 is the second parameter, etc.
     /// @dev The SQL statement to execute
-    function(string memory stmt) external SQLStatementExecute;
+    function(string memory) external sqlStatementExecute;
 
     /// @notice Function that adds a boolean argument to the SQL statement
     /// @dev The boolean value to add
-    function(bool value) external SQLArgBool;
+    function(bool) external sqlArgBool;
 
     /// @notice Function that adds an int64 argument to the SQL statement
     /// @dev The int64 value to add
-    function(int64 value) external SQLArgInt64;
+    function(int64) external sqlArgInt64;
 
     /// @notice Function that adds a uint64 argument to the SQL statement
     /// @dev The uint64 value to add
-    function(uint64 value) external SQLArgUint64;
+    function(uint64) external sqlArgUint64;
 
     /// @notice Function that adds a uint256 argument to the SQL statement
     /// @dev The uint256 value to add
-    function(uint256 value) external SQLArgUint256;
+    function(uint256) external sqlArgUint256;
 
     /// @notice Function that adds a bytes32 argument to the SQL statement
     /// @dev The bytes32 value to add
-    function(bytes32 value) external SQLArgBytes32;
+    function(bytes32) external sqlArgBytes32;
 
     /// @notice Function that adds a bytes argument to the SQL statement
     /// @dev The bytes value to add
-    function(bytes memory value) external SQLArgBytes;
+    function(bytes memory) external sqlArgBytes;
 
     /// @notice Function that adds a string argument to the SQL statement
     /// @dev The string value to add
-    function(string memory value) external SQLArgString;
+    function(string memory) external sqlArgString;
 
     /// @notice Function that adds an address argument to the SQL statement
     /// @dev The address value to add
-    function(address value) external SQLArgAddress;
+    function(address) external sqlArgAddress;
 }
 
 /// @notice Context provided to function-based triggers

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -101,39 +101,39 @@ struct SimFunctions {
     ///         position of the parameter. For example, $1 is the first parameter,
     ///         $2 is the second parameter, etc.
     /// @dev The SQL statement to execute
-    function SQLStatementExecute(string memory stmt);
+    function(string memory stmt) external SQLStatementExecute;
 
     /// @notice Function that adds a boolean argument to the SQL statement
     /// @dev The boolean value to add
-    function SQLArgBool(bool value);
+    function(bool value) external SQLArgBool;
 
     /// @notice Function that adds an int64 argument to the SQL statement
     /// @dev The int64 value to add
-    function SQLArgInt64(int64 value);
+    function(int64 value) external SQLArgInt64;
 
     /// @notice Function that adds a uint64 argument to the SQL statement
     /// @dev The uint64 value to add
-    function SQLArgUint64(uint64 value);
+    function(uint64 value) external SQLArgUint64;
 
     /// @notice Function that adds a uint256 argument to the SQL statement
     /// @dev The uint256 value to add
-    function SQLArgUint256(uint256 value);
+    function(uint256 value) external SQLArgUint256;
 
     /// @notice Function that adds a bytes32 argument to the SQL statement
     /// @dev The bytes32 value to add
-    function SQLArgBytes32(bytes32 value);
+    function(bytes32 value) external SQLArgBytes32;
 
     /// @notice Function that adds a bytes argument to the SQL statement
     /// @dev The bytes value to add
-    function SQLArgBytes(bytes memory value);
+    function(bytes memory value) external SQLArgBytes;
 
     /// @notice Function that adds a string argument to the SQL statement
     /// @dev The string value to add
-    function SQLArgString(string memory value);
+    function(string memory value) external SQLArgString;
 
     /// @notice Function that adds an address argument to the SQL statement
     /// @dev The address value to add
-    function SQLArgAddress(address value);
+    function(address value) external SQLArgAddress;
 }
 
 /// @notice Context provided to function-based triggers

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -95,6 +95,45 @@ struct SimFunctions {
     /// @notice Function that returns the deployer of a contract
     /// @dev The address of the account that deployed the contract
     function(address) external returns (address) getDeployer;
+
+    /// @notice Function that executes a SQL statement. It can use bind parameters.
+    ///         Bind parameters are represented by $<number> where number is the
+    ///         position of the parameter. For example, $1 is the first parameter,
+    ///         $2 is the second parameter, etc.
+    /// @dev The SQL statement to execute
+    function SQLStatementExecute(string memory stmt);
+
+    /// @notice Function that adds a boolean argument to the SQL statement
+    /// @dev The boolean value to add
+    function SQLArgBool(bool value);
+
+    /// @notice Function that adds an int64 argument to the SQL statement
+    /// @dev The int64 value to add
+    function SQLArgInt64(int64 value);
+
+    /// @notice Function that adds a uint64 argument to the SQL statement
+    /// @dev The uint64 value to add
+    function SQLArgUint64(uint64 value);
+
+    /// @notice Function that adds a uint256 argument to the SQL statement
+    /// @dev The uint256 value to add
+    function SQLArgUint256(uint256 value);
+
+    /// @notice Function that adds a bytes32 argument to the SQL statement
+    /// @dev The bytes32 value to add
+    function SQLArgBytes32(bytes32 value);
+
+    /// @notice Function that adds a bytes argument to the SQL statement
+    /// @dev The bytes value to add
+    function SQLArgBytes(bytes memory value);
+
+    /// @notice Function that adds a string argument to the SQL statement
+    /// @dev The string value to add
+    function SQLArgString(string memory value);
+
+    /// @notice Function that adds an address argument to the SQL statement
+    /// @dev The address value to add
+    function SQLArgAddress(address value);
 }
 
 /// @notice Context provided to function-based triggers
@@ -211,6 +250,9 @@ struct RawLogContext {
 /// @notice Context provided to block-based triggers
 /// @dev Used for triggers that fire on block events
 struct RawBlockContext {
+    /// @notice The special functions for state access
+    /// @dev These functions are used to access information which is otherwise hard to get
+    SimFunctions sim;
     /// @notice The block number for this context
     /// @dev The height of the block in the blockchain
     uint256 blockNumber;

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -126,12 +126,59 @@ contract MockContexts {
     }
 
     function mockSimFunctions() external view returns (SimFunctions memory) {
-        SimFunctions memory _sim = SimFunctions({getDeployer: this.getDeployer});
+        SimFunctions memory _sim = SimFunctions({
+            getDeployer: this.getDeployer,
+            SQLStatementExecute: this.SQLStatementExecute,
+            SQLArgBool: this.SQLArgBool,
+            SQLArgInt64: this.SQLArgInt64,
+            SQLArgUint64: this.SQLArgUint64,
+            SQLArgUint256: this.SQLArgUint256,
+            SQLArgBytes32: this.SQLArgBytes32,
+            SQLArgBytes: this.SQLArgBytes,
+            SQLArgString: this.SQLArgString,
+            SQLArgAddress: this.SQLArgAddress
+        });
         return _sim;
     }
 
     function getDeployer(address) external pure returns (address) {
         return address(0);
+    }
+
+    function SQLStatementExecute(string memory stmt) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgBool(bool value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgInt64(int64 value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgUint64(uint64 value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgUint256(uint256 value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgBytes32(bytes32 value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgBytes(bytes memory value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgString(string memory value) external pure returns (void) {
+        return;
+    }
+
+    function SQLArgAddress(address value) external pure returns (void) {
+        return;
     }
 
     function withTransactionIndex(uint64 _transactionIndex) external returns (MockContexts) {

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -145,39 +145,39 @@ contract MockContexts {
         return address(0);
     }
 
-    function SQLStatementExecute(string memory stmt) external pure returns (void) {
+    function SQLStatementExecute(string memory stmt) external pure {
         return;
     }
 
-    function SQLArgBool(bool value) external pure returns (void) {
+    function SQLArgBool(bool value) external pure {
         return;
     }
 
-    function SQLArgInt64(int64 value) external pure returns (void) {
+    function SQLArgInt64(int64 value) external pure {
         return;
     }
 
-    function SQLArgUint64(uint64 value) external pure returns (void) {
+    function SQLArgUint64(uint64 value) external pure {
         return;
     }
 
-    function SQLArgUint256(uint256 value) external pure returns (void) {
+    function SQLArgUint256(uint256 value) external pure {
         return;
     }
 
-    function SQLArgBytes32(bytes32 value) external pure returns (void) {
+    function SQLArgBytes32(bytes32 value) external pure {
         return;
     }
 
-    function SQLArgBytes(bytes memory value) external pure returns (void) {
+    function SQLArgBytes(bytes memory value) external pure {
         return;
     }
 
-    function SQLArgString(string memory value) external pure returns (void) {
+    function SQLArgString(string memory value) external pure {
         return;
     }
 
-    function SQLArgAddress(address value) external pure returns (void) {
+    function SQLArgAddress(address value) external pure {
         return;
     }
 

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -128,15 +128,15 @@ contract MockContexts {
     function mockSimFunctions() external view returns (SimFunctions memory) {
         SimFunctions memory _sim = SimFunctions({
             getDeployer: this.getDeployer,
-            SQLStatementExecute: this.SQLStatementExecute,
-            SQLArgBool: this.SQLArgBool,
-            SQLArgInt64: this.SQLArgInt64,
-            SQLArgUint64: this.SQLArgUint64,
-            SQLArgUint256: this.SQLArgUint256,
-            SQLArgBytes32: this.SQLArgBytes32,
-            SQLArgBytes: this.SQLArgBytes,
-            SQLArgString: this.SQLArgString,
-            SQLArgAddress: this.SQLArgAddress
+            sqlStatementExecute: this.sqlStatementExecute,
+            sqlArgBool: this.sqlArgBool,
+            sqlArgInt64: this.sqlArgInt64,
+            sqlArgUint64: this.sqlArgUint64,
+            sqlArgUint256: this.sqlArgUint256,
+            sqlArgBytes32: this.sqlArgBytes32,
+            sqlArgBytes: this.sqlArgBytes,
+            sqlArgString: this.sqlArgString,
+            sqlArgAddress: this.sqlArgAddress
         });
         return _sim;
     }
@@ -145,39 +145,39 @@ contract MockContexts {
         return address(0);
     }
 
-    function SQLStatementExecute(string memory stmt) external pure {
+    function sqlStatementExecute(string memory stmt) external pure {
         return;
     }
 
-    function SQLArgBool(bool value) external pure {
+    function sqlArgBool(bool) external pure {
         return;
     }
 
-    function SQLArgInt64(int64 value) external pure {
+    function sqlArgInt64(int64) external pure {
         return;
     }
 
-    function SQLArgUint64(uint64 value) external pure {
+    function sqlArgUint64(uint64) external pure {
         return;
     }
 
-    function SQLArgUint256(uint256 value) external pure {
+    function sqlArgUint256(uint256) external pure {
         return;
     }
 
-    function SQLArgBytes32(bytes32 value) external pure {
+    function sqlArgBytes32(bytes32) external pure {
         return;
     }
 
-    function SQLArgBytes(bytes memory value) external pure {
+    function sqlArgBytes(bytes memory) external pure {
         return;
     }
 
-    function SQLArgString(string memory value) external pure {
+    function sqlArgString(string memory) external pure {
         return;
     }
 
-    function SQLArgAddress(address value) external pure {
+    function sqlArgAddress(address) external pure {
         return;
     }
 

--- a/test/Env.t.sol
+++ b/test/Env.t.sol
@@ -16,9 +16,9 @@ contract EnvTest is Test {
         vm.selectFork(chainIdToForkId[1]);
         assertEq(vm.activeFork(), chainIdToForkId[1]);
 
-        vm.rollFork(23583017);
-        assertEq(block.number, 23583017);
-        assertEq(blockNumber(), 23583017);
+        vm.rollFork(23668342);
+        assertEq(block.number, 23668342);
+        assertEq(blockNumber(), 23668342);
     }
 
     function test_blockNumber_arbitrum() public {

--- a/test/GlobalIndex.t.sol
+++ b/test/GlobalIndex.t.sol
@@ -13,8 +13,7 @@ contract GlobalIndexTest is Test {
 
     function test_GlobalIndex() public pure {
         // Create a global index
-        uint120 index =
-            (uint120(BLOCK_NUMBER) << 88) | (uint120(REORG_INCARNATION) << 64) | (uint120(TXN_INDEX) << 40)
+        uint120 index = (uint120(BLOCK_NUMBER) << 88) | (uint120(REORG_INCARNATION) << 64) | (uint120(TXN_INDEX) << 40)
             | uint120(SHADOW_PC);
         assertEq(index, 1329227995784915872903807060280344575, "Global index computation incorrect");
 


### PR DESCRIPTION
Add sim SQL functions to SimFunctions

Also adds the SimFunctions object to RawBlockContext

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds SQL execution and bind-arg functions to `SimFunctions` and includes `sim` in `RawBlockContext`, with mocks and tests updated.
> 
> - **Core API (`src/Context.sol`)**:
>   - Add SQL helpers to `SimFunctions`: `sqlStatementExecute`, `sqlArgBool`, `sqlArgInt64`, `sqlArgUint64`, `sqlArgUint256`, `sqlArgBytes32`, `sqlArgBytes`, `sqlArgString`, `sqlArgAddress`.
>   - Include `SimFunctions sim` in `RawBlockContext`.
> - **Mocks (`src/test/MockContexts.sol`)**:
>   - Populate `mockSimFunctions()` with new SQL functions; add no-op implementations for each.
> - **Tests**:
>   - `test/Env.t.sol`: update forked Ethereum block number.
>   - `test/GlobalIndex.t.sol`: minor formatting and add `test_MockContexts` to verify mock global index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccbf58ae227717067ad06012ce028cc138931fb6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->