### PR TITLE
Add SQL read functions

### DIFF
--- a/src/Context.sol
+++ b/src/Context.sol
@@ -134,6 +134,69 @@ struct SimFunctions {
     /// @notice Function that adds an address argument to the SQL statement
     /// @dev The address value to add
     function(address) external sqlArgAddress;
+
+    /// @notice Function that executes a SQL SELECT query. It can use bind parameters.
+    ///         Bind parameters are represented by $<number> where number is the
+    ///         position of the parameter. For example, $1 is the first parameter,
+    ///         $2 is the second parameter, etc.
+    /// @dev The SQL statement to execute
+    // @return hasResult True if the query returned results
+    function(string memory) external returns (bool) sqlQuery;
+
+    /// @notice Function that returns the number of rows in the current result.
+    /// @dev Gets the row count from the last query
+    // @return rowCount The number of rows in the result set
+    function() external returns (uint64) sqlRowCount;
+
+    /// @notice Function that retrieves a boolean value from the requested column
+    /// @dev Gets a boolean from the specified column in the current row
+    // @return value The boolean value from the specified column
+    function(string memory) external returns (bool) sqlArgGetAsBool;
+
+    /// @notice Function that retrieves an int64 value from the requested column
+    /// @dev Gets an int64 from the specified column in the current row
+    // @return value The int64 value from the specified column
+    function(string memory) external returns (int64) sqlArgGetAsInt64;
+
+    /// @notice Function that retrieves an int256 value from the requested column
+    /// @dev Gets an int256 from the specified column in the current row
+    // @return value The int256 value from the specified column
+    function(string memory) external returns (int256) sqlArgGetAsInt256;
+
+    /// @notice Function that retrieves an address value from the requested column
+    /// @dev Gets an address from the specified column in the current row
+    // @return value The address value from the specified column
+    function(string memory) external returns (address) sqlArgGetAsAddress;
+
+    /// @notice Function that retrieves a uint64 value from the requested column
+    /// @dev Gets a uint64 from the specified column in the current row
+    // @return value The uint64 value from the specified column
+    function(string memory) external returns (uint64) sqlArgGetAsUint64;
+
+    /// @notice Function that retrieves a uint256 value from the requested column
+    /// @dev Gets a uint256 from the specified column in the current row
+    // @return value The uint256 value from the specified column
+    function(string memory) external returns (uint256) sqlArgGetAsUint256;
+
+    /// @notice Function that retrieves a string value from the requested column
+    /// @dev Gets a string from the specified column in the current row
+    // @return value The string value from the specified column
+    function(string memory) external returns (string memory) sqlArgGetAsString;
+
+    /// @notice Function that retrieves a bytes value from the requested column
+    /// @dev Gets bytes from the specified column in the current row
+    // @return value The bytes value from the specified column
+    function(string memory) external returns (bytes memory) sqlArgGetAsBytes;
+
+    /// @notice Function that retrieves a bytes32 value from the requested column
+    /// @dev Gets a bytes32 from the specified column in the current row
+    // @return value The bytes32 value from the specified column
+    function(string memory) external returns (bytes32) sqlArgGetAsBytes32;
+
+    /// @notice Function that advances to the next row in the result set
+    /// @dev Moves the cursor to the next row, returns false if no more rows
+    // @return hasMoreRows True if there are more rows to fetch
+    function() external returns (bool) sqlNextRow;
 }
 
 /// @notice Context provided to function-based triggers

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -140,62 +140,62 @@ struct SimFunctions {
     ///         position of the parameter. For example, $1 is the first parameter,
     ///         $2 is the second parameter, etc.
     /// @dev The SQL statement to execute
-    // @return hasResult True if the query returned results
+    /// @return hasResult True if the query returned results
     function(string memory) external returns (bool) sqlQuery;
 
     /// @notice Function that returns the number of rows in the current result.
     /// @dev Gets the row count from the last query
-    // @return rowCount The number of rows in the result set
+    /// @return rowCount The number of rows in the result set
     function() external returns (uint64) sqlRowCount;
 
     /// @notice Function that retrieves a boolean value from the requested column
     /// @dev Gets a boolean from the specified column in the current row
-    // @return value The boolean value from the specified column
+    /// @return value The boolean value from the specified column
     function(string memory) external returns (bool) sqlArgGetAsBool;
 
     /// @notice Function that retrieves an int64 value from the requested column
     /// @dev Gets an int64 from the specified column in the current row
-    // @return value The int64 value from the specified column
+    /// @return value The int64 value from the specified column
     function(string memory) external returns (int64) sqlArgGetAsInt64;
 
     /// @notice Function that retrieves an int256 value from the requested column
     /// @dev Gets an int256 from the specified column in the current row
-    // @return value The int256 value from the specified column
+    /// @return value The int256 value from the specified column
     function(string memory) external returns (int256) sqlArgGetAsInt256;
 
     /// @notice Function that retrieves an address value from the requested column
     /// @dev Gets an address from the specified column in the current row
-    // @return value The address value from the specified column
+    /// @return value The address value from the specified column
     function(string memory) external returns (address) sqlArgGetAsAddress;
 
     /// @notice Function that retrieves a uint64 value from the requested column
     /// @dev Gets a uint64 from the specified column in the current row
-    // @return value The uint64 value from the specified column
+    /// @return value The uint64 value from the specified column
     function(string memory) external returns (uint64) sqlArgGetAsUint64;
 
     /// @notice Function that retrieves a uint256 value from the requested column
     /// @dev Gets a uint256 from the specified column in the current row
-    // @return value The uint256 value from the specified column
+    /// @return value The uint256 value from the specified column
     function(string memory) external returns (uint256) sqlArgGetAsUint256;
 
     /// @notice Function that retrieves a string value from the requested column
     /// @dev Gets a string from the specified column in the current row
-    // @return value The string value from the specified column
+    /// @return value The string value from the specified column
     function(string memory) external returns (string memory) sqlArgGetAsString;
 
     /// @notice Function that retrieves a bytes value from the requested column
     /// @dev Gets bytes from the specified column in the current row
-    // @return value The bytes value from the specified column
+    /// @return value The bytes value from the specified column
     function(string memory) external returns (bytes memory) sqlArgGetAsBytes;
 
     /// @notice Function that retrieves a bytes32 value from the requested column
     /// @dev Gets a bytes32 from the specified column in the current row
-    // @return value The bytes32 value from the specified column
+    /// @return value The bytes32 value from the specified column
     function(string memory) external returns (bytes32) sqlArgGetAsBytes32;
 
     /// @notice Function that advances to the next row in the result set
     /// @dev Moves the cursor to the next row, returns false if no more rows
-    // @return hasMoreRows True if there are more rows to fetch
+    /// @return hasMoreRows True if there are more rows to fetch
     function() external returns (bool) sqlNextRow;
 }
 

--- a/src/test/MockContexts.sol
+++ b/src/test/MockContexts.sol
@@ -136,7 +136,19 @@ contract MockContexts {
             sqlArgBytes32: this.sqlArgBytes32,
             sqlArgBytes: this.sqlArgBytes,
             sqlArgString: this.sqlArgString,
-            sqlArgAddress: this.sqlArgAddress
+            sqlArgAddress: this.sqlArgAddress,
+            sqlQuery: this.sqlQuery,
+            sqlRowCount: this.sqlRowCount,
+            sqlArgGetAsBool: this.sqlArgGetAsBool,
+            sqlArgGetAsInt64: this.sqlArgGetAsInt64,
+            sqlArgGetAsInt256: this.sqlArgGetAsInt256,
+            sqlArgGetAsAddress: this.sqlArgGetAsAddress,
+            sqlArgGetAsUint64: this.sqlArgGetAsUint64,
+            sqlArgGetAsUint256: this.sqlArgGetAsUint256,
+            sqlArgGetAsString: this.sqlArgGetAsString,
+            sqlArgGetAsBytes: this.sqlArgGetAsBytes,
+            sqlArgGetAsBytes32: this.sqlArgGetAsBytes32,
+            sqlNextRow: this.sqlNextRow
         });
         return _sim;
     }
@@ -145,7 +157,7 @@ contract MockContexts {
         return address(0);
     }
 
-    function sqlStatementExecute(string memory stmt) external pure {
+    function sqlStatementExecute(string memory) external pure {
         return;
     }
 
@@ -179,6 +191,58 @@ contract MockContexts {
 
     function sqlArgAddress(address) external pure {
         return;
+    }
+
+    function sqlArgInt256(int256) external pure {
+        return;
+    }
+
+    function sqlQuery(string memory) external pure returns (bool) {
+        return false;
+    }
+
+    function sqlRowCount() external pure returns (uint64) {
+        return 0;
+    }
+
+    function sqlArgGetAsBool(string memory) external pure returns (bool) {
+        return false;
+    }
+
+    function sqlArgGetAsInt64(string memory) external pure returns (int64) {
+        return 0;
+    }
+
+    function sqlArgGetAsInt256(string memory) external pure returns (int256) {
+        return 0;
+    }
+
+    function sqlArgGetAsAddress(string memory) external pure returns (address) {
+        return address(0);
+    }
+
+    function sqlArgGetAsUint64(string memory) external pure returns (uint64) {
+        return 0;
+    }
+
+    function sqlArgGetAsUint256(string memory) external pure returns (uint256) {
+        return 0;
+    }
+
+    function sqlArgGetAsString(string memory) external pure returns (string memory) {
+        return "";
+    }
+
+    function sqlArgGetAsBytes(string memory) external pure returns (bytes memory) {
+        return "";
+    }
+
+    function sqlArgGetAsBytes32(string memory) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function sqlNextRow() external pure returns (bool) {
+        return false;
     }
 
     function withTransactionIndex(uint64 _transactionIndex) external returns (MockContexts) {

--- a/test/Env.t.sol
+++ b/test/Env.t.sol
@@ -16,9 +16,9 @@ contract EnvTest is Test {
         vm.selectFork(chainIdToForkId[1]);
         assertEq(vm.activeFork(), chainIdToForkId[1]);
 
-        vm.rollFork(23668342);
-        assertEq(block.number, 23668342);
-        assertEq(blockNumber(), 23668342);
+        vm.rollFork(23718054);
+        assertEq(block.number, 23718054);
+        assertEq(blockNumber(), 23718054);
     }
 
     function test_blockNumber_arbitrum() public {


### PR DESCRIPTION
Towards IDX-1141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce SQL SELECT/query functions and result accessors in `SimFunctions`, update `MockContexts` stubs, and refresh block number in `Env` test.
> 
> - **Context (`src/Context.sol`)**:
>   - Add SQL read/query APIs to `SimFunctions`:
>     - `sqlQuery`, `sqlRowCount`, `sqlNextRow`
>     - Column getters: `sqlArgGetAsBool`, `sqlArgGetAsInt64`, `sqlArgGetAsInt256`, `sqlArgGetAsAddress`, `sqlArgGetAsUint64`, `sqlArgGetAsUint256`, `sqlArgGetAsString`, `sqlArgGetAsBytes`, `sqlArgGetAsBytes32`
> - **Mocks (`src/test/MockContexts.sol`)**:
>   - Wire new functions into `mockSimFunctions()` and add no-op implementations for all new SQL APIs.
>   - Minor: remove unused param name in `sqlStatementExecute`.
> - **Tests (`test/Env.t.sol`)**:
>   - Update Ethereum fork block number assertions in `test_blockNumber()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c676463d7b42616c53ff89a95350fed3375a31fc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->